### PR TITLE
Adds Admin role client

### DIFF
--- a/okta/AdminRolesClient.py
+++ b/okta/AdminRolesClient.py
@@ -21,12 +21,25 @@ class AdminRolesClient(ApiClient):
     def assign_roles_to_user(self, uid, role_type):
         """Assigns a role to a user.
 
-        :param uid: str
-        :param role_type: str
+        :param uid: User id: str
+        :param role_type: Role type: str
         :return: Role
         """
         data = {
             'type': role_type
         }
         response = ApiClient.post_path(self, '/{0}/roles'.format(uid), data)
+        return Utils.deserialize(response.text, Role)
+
+    def unassign_role_from_user(self, uid, rid):
+        """Unassigns a role from a user.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :return: Role
+        """
+        response = ApiClient.delete_path(
+            self,
+            '/{uid}/roles/{rid}'.format(uid=uid, rid=rid)
+        )
         return Utils.deserialize(response.text, Role)

--- a/okta/AdminRolesClient.py
+++ b/okta/AdminRolesClient.py
@@ -1,6 +1,7 @@
 from okta.framework.ApiClient import ApiClient
 from okta.framework.Utils import Utils
 from okta.models.role.Role import Role
+from okta.models.usergroup import UserGroup
 
 
 class AdminRolesClient(ApiClient):
@@ -36,10 +37,39 @@ class AdminRolesClient(ApiClient):
 
         :param uid: User id: str
         :param rid: Role id: str
-        :return: Role
+        :return: None
         """
-        response = ApiClient.delete_path(
+        ApiClient.delete_path(
             self,
             '/{uid}/roles/{rid}'.format(uid=uid, rid=rid)
         )
-        return Utils.deserialize(response.text, Role)
+
+    def get_group_targets_for_user_role_assignment(self, uid, rid):
+        """Lists all group targets for a USER_ADMIN role assignment.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :return: list of Groups
+        """
+        response = ApiClient.get_path(
+            self,
+            '/{uid}/roles/{rid}/targets/groups'.format(uid=uid, rid=rid)
+        )
+        return Utils.deserialize(response.text, UserGroup)
+
+    def add_target_for_user_admin_role(self, uid, rid, gid):
+        """Adds a group target for a USER_ADMIN role assignment.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :param gid: Group id: str
+        :return: None
+        """
+        ApiClient.put_path(
+            self,
+            '/{uid}/roles/{rid}/targets/groups/{gid}'.format(
+                uid=uid,
+                rid=rid,
+                gid=gid
+            )
+        )

--- a/okta/AdminRolesClient.py
+++ b/okta/AdminRolesClient.py
@@ -1,0 +1,32 @@
+from okta.framework.ApiClient import ApiClient
+from okta.framework.Utils import Utils
+from okta.models.role.Role import Role
+
+
+class AdminRolesClient(ApiClient):
+    def __init__(self, *args, **kwargs):
+        kwargs['pathname'] = '/api/v1/users'
+        ApiClient.__init__(self, *args, **kwargs)
+
+    def get_user_admin_roles(self, uid):
+        """Get all roles assigned to a user.
+
+        :param uid: the user id
+        :type uid: str
+        :rtype: list of Role
+        """
+        response = ApiClient.get_path(self, '/{0}/roles'.format(uid))
+        return Utils.deserialize(response.text, Role)
+
+    def assign_roles_to_user(self, uid, role_type):
+        """Assigns a role to a user.
+
+        :param uid: str
+        :param role_type: str
+        :return: Role
+        """
+        data = {
+            'type': role_type
+        }
+        response = ApiClient.post_path(self, '/{0}/roles'.format(uid), data)
+        return Utils.deserialize(response.text, Role)

--- a/okta/AdminRolesClient.py
+++ b/okta/AdminRolesClient.py
@@ -1,5 +1,6 @@
 from okta.framework.ApiClient import ApiClient
 from okta.framework.Utils import Utils
+from okta.models.app.AppInstance import AppInstance
 from okta.models.role.Role import Role
 from okta.models.usergroup import UserGroup
 
@@ -57,7 +58,7 @@ class AdminRolesClient(ApiClient):
         )
         return Utils.deserialize(response.text, UserGroup)
 
-    def add_target_for_user_admin_role(self, uid, rid, gid):
+    def add_group_target_for_user_admin_role(self, uid, rid, gid):
         """Adds a group target for a USER_ADMIN role assignment.
 
         :param uid: User id: str
@@ -71,5 +72,69 @@ class AdminRolesClient(ApiClient):
                 uid=uid,
                 rid=rid,
                 gid=gid
+            )
+        )
+
+    def remove_group_target_from_user_admin_role(self, uid, rid, gid):
+        """Removes a group target from a USER_ADMIN role assignment.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :param gid: Group id: str
+        :return: None
+        """
+        ApiClient.delete_path(
+            self,
+            '/{uid}/roles/{rid}/targets/groups/{gid}'.format(
+                uid=uid,
+                rid=rid,
+                gid=gid
+            )
+        )
+
+    def get_app_targets_for_app_role(self, uid, rid):
+        """Lists all app targets for an APP_ADMIN role assignment.
+
+                :param uid: User id: str
+                :param rid: Role id: str
+                :return: list of Catalog Apps
+                """
+        response = ApiClient.get_path(
+            self,
+            '/{uid}/roles/{rid}/targets/catalog/apps'.format(uid=uid, rid=rid)
+        )
+        return Utils.deserialize(response.text, AppInstance)
+
+    def add_app_target_to_app_admin_role(self, uid, rid, app_name):
+        """Adds a app target to an APP_ADMIN role assignment.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :param app_name: App name: str
+        :return: None
+        """
+        ApiClient.put_path(
+            self,
+            '/{uid}/roles/{rid}/targets/catalog/apps/{app_name}'.format(
+                uid=uid,
+                rid=rid,
+                app_name=app_name
+            )
+        )
+
+    def remove_app_target_to_app_admin_role(self, uid, rid, app_name):
+        """Removes a app target to an APP_ADMIN role assignment.
+
+        :param uid: User id: str
+        :param rid: Role id: str
+        :param app_name: App name: str
+        :return: None
+        """
+        ApiClient.delete_path(
+            self,
+            '/{uid}/roles/{rid}/targets/catalog/apps/{app_name}'.format(
+                uid=uid,
+                rid=rid,
+                app_name=app_name
             )
         )

--- a/okta/models/role/Role.py
+++ b/okta/models/role/Role.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+
+class Role:
+    types = {
+        'id': str,
+        'label': str,
+        'type': str,
+        'status': str,
+        'created': datetime,
+        'lastUpdated': datetime,
+    }
+
+    def __init__(self, **kwargs):
+
+        # unique key for user
+        self.id = None  # str
+
+        # display name of role
+        self.label = None  # str
+
+        # type of role
+        self.type = None  # SUPER_ADMIN, ORG_ADMIN, APP_ADMIN, USER_ADMIN,
+        # MOBILE_ADMIN, READ_ONLY_ADMIN
+
+        # status of role assignment
+        self.status = None  # str
+
+        # timestamp when app user was created
+        self.created = None  # datetime
+
+        # timestamp when app user was last updated
+        self.lastUpdated = None  # datetime

--- a/tests/AdminRolesClientTest.py
+++ b/tests/AdminRolesClientTest.py
@@ -1,0 +1,77 @@
+import json
+import os
+import unittest
+
+from okta import UsersClient
+from okta.AdminRolesClient import AdminRolesClient
+
+config_path = os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                            '../.sdk.config.json'))
+
+with open(config_path) as sdk_config_data:
+    sdk_config = json.load(sdk_config_data)
+
+
+def build_admin_roles_client(test_description):
+    url = '{}:{}'.format(sdk_config['mockOkta']['proxy'],
+                         sdk_config['mockOkta']['port'])
+    return AdminRolesClient(
+        base_url=url,
+        api_token=sdk_config['mockOkta']['apiKey'],
+        headers={
+            'x-test-description': test_description
+        }
+    )
+
+
+def build_users_client(test_description):
+    url = '{}:{}'.format(sdk_config['mockOkta']['proxy'],
+                         sdk_config['mockOkta']['port'])
+    return UsersClient(
+        base_url=url,
+        api_token=sdk_config['mockOkta']['apiKey'],
+        headers={
+            'x-test-description': test_description
+        }
+    )
+
+
+class AdminRolesClientTest(unittest.TestCase):
+    @staticmethod
+    def tests_client_initializer_args():
+        AdminRolesClient('https://example.okta.com', 'api_key')
+
+    @staticmethod
+    def tests_client_initializer_kwargs():
+        AdminRolesClient(base_url='https://example.okta.com',
+                         api_token='api_key')
+
+    @staticmethod
+    def test_get_user_admin_roles():
+        users_client = build_users_client(
+            '/api/v1/users/:id/roles - get all roles assigned to a user')
+
+        user = users_client.get_user(
+            'mocktestexample-frutis@mocktestexample.com'
+        )
+
+        admin_roles_client = build_admin_roles_client(
+            '/api/v1/users/:id/roles - get all roles assigned to a user'
+        )
+
+        admin_roles_client.get_user_admin_roles(user.id)
+
+    @staticmethod
+    def test_assign_role_to_user():
+        users_client = build_users_client(
+            '/api/v1/users/:id/roles - assign role to a user')
+
+        user = users_client.get_user(
+            'mocktestexample-frutis@mocktestexample.com'
+        )
+
+        admin_roles_client = build_admin_roles_client(
+            '/api/v1/users/:id/roles - assign role to a user'
+        )
+
+        admin_roles_client.assign_roles_to_user(user.id, 'ORG_ADMIN')

--- a/tests/AdminRolesClientTest.py
+++ b/tests/AdminRolesClientTest.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 
+from okta import AppInstanceClient
 from okta import UserGroupsClient
 from okta import UsersClient
 from okta.AdminRolesClient import AdminRolesClient
@@ -41,6 +42,18 @@ def build_user_groups_client(test_description):
     url = '{}:{}'.format(sdk_config['mockOkta']['proxy'],
                          sdk_config['mockOkta']['port'])
     return UserGroupsClient(
+        base_url=url,
+        api_token=sdk_config['mockOkta']['apiKey'],
+        headers={
+            'x-test-description': test_description
+        }
+    )
+
+
+def build_app_client(test_description):
+    url = '{}:{}'.format(sdk_config['mockOkta']['proxy'],
+                         sdk_config['mockOkta']['port'])
+    return AppInstanceClient(
         base_url=url,
         api_token=sdk_config['mockOkta']['apiKey'],
         headers={
@@ -137,8 +150,88 @@ class AdminRolesClientTest(unittest.TestCase):
         role = admin_roles_client.get_user_admin_roles(user.id)[0]
         group = user_groups_client.get_groups()[1]
 
-        admin_roles_client.add_target_for_user_admin_role(
+        admin_roles_client.add_group_target_for_user_admin_role(
             user.id,
             role.id,
             group.id
+        )
+
+    @staticmethod
+    def test_assign_app_admin_role_to_user():
+        test_description = '/api/v1/users/:id/roles - assign APP_ADMIN role ' \
+                           'to a user'
+        users_client = build_users_client(test_description)
+
+        user = users_client.get_user(
+            'mocktestexample-applicationrolus@mocktestexample.com'
+        )
+        admin_roles_client = build_admin_roles_client(test_description)
+
+        admin_roles_client.assign_roles_to_user(user.id, 'APP_ADMIN')
+
+    @staticmethod
+    def test_get_app_targets_for_app_admin_role():
+        test_description = '/api/v1/users/:uid/roles/:rid/targets/' \
+                           'catalog/apps - get all app targets for an ' \
+                           'APP_ADMIN role assignment'
+        users_client = build_users_client(test_description)
+        admin_roles_client = build_admin_roles_client(test_description)
+
+        user = users_client.get_user(
+            'mocktestexample-applicationrolus@mocktestexample.com'
+        )
+        role = admin_roles_client.get_user_admin_roles(user.id)[0]
+        admin_roles_client.get_app_targets_for_app_role(
+            user.id,
+            role.id
+        )
+
+    @staticmethod
+    def test_add_app_target_to_app_admin_role():
+        test_description = '/api/v1/users/:uid/roles/:rid/targets/' \
+                           'catalog/apps - adds an app target for an ' \
+                           'APP_ADMIN role assignment'
+        users_client = build_users_client(test_description)
+        admin_roles_client = build_admin_roles_client(test_description)
+        app_client = build_app_client(test_description)
+
+        user = users_client.get_user(
+            'mocktestexample-applicationrolus@mocktestexample.com'
+        )
+
+        role = admin_roles_client.get_user_admin_roles(user.id)[0]
+        app = app_client.get_app_instances()[0]
+
+        admin_roles_client.add_app_target_to_app_admin_role(
+            user.id,
+            role.id,
+            app.name
+        )
+
+    @staticmethod
+    def test_removes_add_app_target_to_app_admin_role():
+        test_description = '/api/v1/users/:uid/roles/:rid/targets/' \
+                           'catalog/apps - removes an app target for an ' \
+                           'APP_ADMIN role assignment'
+        users_client = build_users_client(test_description)
+        admin_roles_client = build_admin_roles_client(test_description)
+        app_client = build_app_client(test_description)
+
+        user = users_client.get_user(
+            'mocktestexample-applicationrolus@mocktestexample.com'
+        )
+
+        role = admin_roles_client.get_user_admin_roles(user.id)[0]
+        app = app_client.get_app_instances()[0]
+
+        admin_roles_client.add_app_target_to_app_admin_role(
+            user.id,
+            role.id,
+            app.name
+        )
+
+        admin_roles_client.remove_app_target_to_app_admin_role(
+            user.id,
+            role.id,
+            app.name
         )

--- a/tests/AdminRolesClientTest.py
+++ b/tests/AdminRolesClientTest.py
@@ -75,3 +75,18 @@ class AdminRolesClientTest(unittest.TestCase):
         )
 
         admin_roles_client.assign_roles_to_user(user.id, 'ORG_ADMIN')
+
+    @staticmethod
+    def test_unassign_role_from_user():
+        users_client = build_users_client(
+            '/api/v1/users/:id/roles/:rid - unassign role from user')
+        user = users_client.get_user(
+            'mocktestexample-frutis@mocktestexample.com'
+        )
+
+        admin_roles_client = build_admin_roles_client(
+            '/api/v1/users/:id/roles/:rid - unassign role from user'
+        )
+
+        roles = admin_roles_client.get_user_admin_roles(user.id)
+        admin_roles_client.unassign_role_from_user(user.id, roles[0].id)

--- a/tools/mock-okta/test/prep.js
+++ b/tools/mock-okta/test/prep.js
@@ -84,9 +84,34 @@ function createUpdateGroup() {
   }).then(group => console.log(`Test Prep: Created group ${group.profile.name}`));
 }
 
+// Creates an Application
+function createApplication() {
+  return req.post({
+    path: '/api/v1/apps',
+    body: {
+      label: 'Example Custom SWA App',
+      visibility: {
+        autoSubmitToolbar: false,
+        hide: {
+          iOS: false,
+          web: false
+        }
+      },
+      features: [],
+      signOnMode: 'AUTO_LOGIN',
+      settings: {
+        signOn: {
+          redirectUrl: 'http://swasecondaryredirecturl.okta.com',
+          loginUrl: 'http://swaprimaryloginurl.okta.com'
+        }
+      }
+    }
+  }).then(app => console.log(`Test Prep: Created application ${app.label}`));
+}
+
 Promise.all([
   createUsers(),
+  createApplication(),
   createDeleteGroup(),
   createUpdateGroup(),
-])
-.catch((err) => { throw new Error('Error:', err.message); });
+]).catch((err) => { throw new Error('Error:', err.message); });

--- a/tools/mock-okta/test/suites/roles.js
+++ b/tools/mock-okta/test/suites/roles.js
@@ -1,0 +1,25 @@
+const util = require('../util');
+
+util.describe('/api/v1/users/:id/roles', (suite) => {
+  suite.it('assign role to a user', req =>
+    req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
+      .then(user =>
+        req.post(
+            {
+                path: `/api/v1/users/${user.id}/roles`,
+                body: {
+                    type: 'ORG_ADMIN',
+                },
+            })
+      )
+    );
+
+  suite.it('get all roles assigned to a user', req =>
+    req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com' })
+      .then(user =>
+          req.get({
+              path: `/api/v1/users/${user.id}/roles`
+          }))
+    );
+
+});

--- a/tools/mock-okta/test/suites/roles.js
+++ b/tools/mock-okta/test/suites/roles.js
@@ -2,19 +2,88 @@ const util = require('../util');
 
 util.describe('/api/v1/users/:id/roles', (suite) => {
   suite.it('assign role to a user', req =>
-    req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
+    req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
       .then(user =>
-        req.post({ path: `/api/v1/users/${user.id}/roles`,
-                body: { type: 'USER_ADMIN' } })
+        req.post({
+          path: `/api/v1/users/${user.id}/roles`,
+          body: {type: 'USER_ADMIN'}
+        })
       ));
 
   suite.it('get all roles assigned to a user', req =>
-    req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com' })
+    req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
       .then(user =>
-          req.get({
-              path: `/api/v1/users/${user.id}/roles`
-          }))
-    );
+        req.get({
+          path: `/api/v1/users/${user.id}/roles`
+        }))
+  );
+  suite.it('assign APP_ADMIN role to a user', req =>
+    req.get({path: '/api/v1/users/mocktestexample-applicationrolus@mocktestexample.com'})
+      .then(user =>
+        req.post({
+          path: `/api/v1/users/${user.id}/roles`,
+          body: {type: 'APP_ADMIN'}
+        })
+      )
+  );
+});
+
+util.describe('/api/v1/users/:uid/roles/:rid/targets/catalog/apps', (suite) => {
+  suite.it('get all app targets for an APP_ADMIN role assignment', req => {
+    "use strict";
+    let userPromise = req.get({path: '/api/v1/users/mocktestexample-applicationrolus@mocktestexample.com'})
+      .then(user => { return user });
+
+    Promise.all([userPromise]).then(function (results) {
+      let userId = results[0].id;
+      req.get({path: `/api/v1/users/${userId}/roles`}).then(
+        roles => {
+          req.get({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/catalog/apps`})
+        }
+      )
+    });
+  });
+
+  suite.it('adds an app target for an APP_ADMIN role assignment', req => {
+    "use strict";
+    let userPromise = req.get({path: '/api/v1/users/mocktestexample-applicationrolus@mocktestexample.com'})
+      .then(user => { return user });
+
+    let appPromise = req.get({path: '/api/v1/apps'}).then(app => { return app });
+
+    Promise.all([userPromise, appPromise]).then(function (results) {
+      let userId = results[0].id;
+      let appName = results[1][0].name;
+
+      req.get({path: `/api/v1/users/${userId}/roles`}).then(
+        roles => {
+          req.put({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/catalog/apps/${appName}`});
+        }
+      )
+    });
+  });
+
+  suite.it('removes an app target for an APP_ADMIN role assignment', req => {
+    "use strict";
+    let userPromise = req.get({path: '/api/v1/users/mocktestexample-applicationrolus@mocktestexample.com'})
+      .then(user => { return user });
+
+    let appPromise = req.get({path: '/api/v1/apps'}).then(app => { return app });
+
+    Promise.all([userPromise, appPromise]).then(function (results) {
+      let userId = results[0].id;
+      let appName = results[1][0].name;
+
+      req.get({path: `/api/v1/users/${userId}/roles`}).then(
+        roles => {
+          req.put({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/catalog/apps/${appName}`})
+            .then(() => {
+            req.del({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/catalog/apps/${appName}`})}
+            );
+        }
+      )
+    });
+  });
 });
 
 util.describe('/api/v1/users/:uid/roles/:rid/targets/groups/:gid', (suite) => {
@@ -22,18 +91,22 @@ util.describe('/api/v1/users/:uid/roles/:rid/targets/groups/:gid', (suite) => {
     "use strict";
 
     let userPromise = req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
-      .then(user => { return user });
+      .then(user => {
+        return user
+      });
 
-    let groupPromise = req.get({path: '/api/v1/groups'}).then(groups => { return groups });
+    let groupPromise = req.get({path: '/api/v1/groups'}).then(groups => {
+      return groups
+    });
 
     Promise.all([userPromise, groupPromise]).then(function (results) {
       let userId = results[0].id;
       let groupId = results[1][1].id; // Group 0 is Everyone
       req.get({path: `/api/v1/users/${userId}/roles`}).then(
         roles => {
-        req.put({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/groups/${groupId}`})
-      }
-    )
+          req.put({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/groups/${groupId}`})
+        }
+      )
     });
   });
 
@@ -45,7 +118,7 @@ util.describe('/api/v1/users/:uid/roles/:rid/targets/groups/:gid', (suite) => {
             req.get({path: `/api/v1/users/${user.id}/roles/${roles[0].id}/targets/groups`});
           })
       })
-    );
+  );
 });
 
 
@@ -58,5 +131,5 @@ util.describe('/api/v1/users/:id/roles/:rid', (suite) => {
             req.del({path: `/api/v1/users/${user.id}/roles/${roles[0].id}`})
           })
       })
-    );
+  );
 });

--- a/tools/mock-okta/test/suites/roles.js
+++ b/tools/mock-okta/test/suites/roles.js
@@ -21,5 +21,16 @@ util.describe('/api/v1/users/:id/roles', (suite) => {
               path: `/api/v1/users/${user.id}/roles`
           }))
     );
+});
 
+util.describe('/api/v1/users/:id/roles/:rid', (suite) => {
+  suite.it('unassign role from user', req =>
+    req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
+      .then(user => {
+        req.get({path: `/api/v1/users/${user.id}/roles`})
+          .then(roles => {
+            req.del({path: `/api/v1/users/${user.id}/roles/${roles[0].id}`})
+          })
+      })
+    );
 });

--- a/tools/mock-okta/test/suites/roles.js
+++ b/tools/mock-okta/test/suites/roles.js
@@ -4,15 +4,9 @@ util.describe('/api/v1/users/:id/roles', (suite) => {
   suite.it('assign role to a user', req =>
     req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
       .then(user =>
-        req.post(
-            {
-                path: `/api/v1/users/${user.id}/roles`,
-                body: {
-                    type: 'ORG_ADMIN',
-                },
-            })
-      )
-    );
+        req.post({ path: `/api/v1/users/${user.id}/roles`,
+                body: { type: 'USER_ADMIN' } })
+      ));
 
   suite.it('get all roles assigned to a user', req =>
     req.get({ path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com' })
@@ -22,6 +16,38 @@ util.describe('/api/v1/users/:id/roles', (suite) => {
           }))
     );
 });
+
+util.describe('/api/v1/users/:uid/roles/:rid/targets/groups/:gid', (suite) => {
+  suite.it('adds a group target for a USER_ADMIN role assignment', req => {
+    "use strict";
+
+    let userPromise = req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
+      .then(user => { return user });
+
+    let groupPromise = req.get({path: '/api/v1/groups'}).then(groups => { return groups });
+
+    Promise.all([userPromise, groupPromise]).then(function (results) {
+      let userId = results[0].id;
+      let groupId = results[1][1].id; // Group 0 is Everyone
+      req.get({path: `/api/v1/users/${userId}/roles`}).then(
+        roles => {
+        req.put({path: `/api/v1/users/${userId}/roles/${roles[0].id}/targets/groups/${groupId}`})
+      }
+    )
+    });
+  });
+
+  suite.it('get all group targets for a USER_ADMIN role assignment', req =>
+    req.get({path: '/api/v1/users/mocktestexample-frutis@mocktestexample.com'})
+      .then(user => {
+        req.get({path: `/api/v1/users/${user.id}/roles`})
+          .then(roles => {
+            req.get({path: `/api/v1/users/${user.id}/roles/${roles[0].id}/targets/groups`});
+          })
+      })
+    );
+});
+
 
 util.describe('/api/v1/users/:id/roles/:rid', (suite) => {
   suite.it('unassign role from user', req =>

--- a/tools/mock-okta/test/testUsers.json
+++ b/tools/mock-okta/test/testUsers.json
@@ -14,6 +14,19 @@
   },
   {
     "profile": {
+      "firstName": "ApplicationRolus",
+      "lastName": "McJanky",
+      "email": "mocktestexample-applicationrolus@mocktestexample.com",
+      "login": "mocktestexample-applicationrolus@mocktestexample.com"
+    },
+    "credentials": {
+      "password": {
+        "value": "Asdf1234"
+      }
+    }
+  },
+  {
+    "profile": {
       "firstName": "Deletus",
       "lastName": "McJanky",
       "email": "mocktestexample-deleteme@mocktestexample.com",


### PR DESCRIPTION
🌱 Adds Admin Role client to get/assign/unassign roles of an User.

It implements the logic to interact with all the endpoints described in the [Admin Roles API documentation](http://developer.okta.com/docs/api/resources/roles.html#app-admin-role-app-targets).

Address #42 