### PR TITLE
Issue 52 - Cannot use Auth API for authentication only

### DIFF
--- a/okta/framework/ApiClient.py
+++ b/okta/framework/ApiClient.py
@@ -24,7 +24,8 @@ class ApiClient(object):
         elif len(args) > 1 and args[1]:
             self.api_token = args[1]
         else:
-            raise ValueError('An api_token must be provied to create an ApiClient')
+            # raise ValueError('An api_token must be provied to create an ApiClient')
+            pass
 
         self.api_version = 1
         self.max_attempts = 4

--- a/okta/framework/ApiClient.py
+++ b/okta/framework/ApiClient.py
@@ -30,11 +30,17 @@ class ApiClient(object):
         self.api_version = 1
         self.max_attempts = 4
 
-        self.headers = {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'Authorization': 'SSWS ' + self.api_token
-        }
+        if kwargs['pathname'] == '/api/v1/authn':
+            self.headers = {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            }
+        else:
+            self.headers = {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': 'SSWS ' + self.api_token
+            }
 
         if 'headers' in kwargs:
             self.headers.update(kwargs['headers'])

--- a/tests/AuthClientTest.py
+++ b/tests/AuthClientTest.py
@@ -11,3 +11,10 @@ class AuthClientTest(unittest.TestCase):
 
     def tests_client_initializer_kwargs(self):
         client = AuthClient(base_url='https://example.okta.com', api_token='api_key')
+
+
+    def tests_client_initializer_args_2(self):
+        client = AuthClient('https://example.okta.com')
+
+    def tests_client_initializer_kwargs_2(self):
+        client = AuthClient(base_url='https://example.okta.com')


### PR DESCRIPTION
- added some logic in ApiClient.py to remove 'Authorization':  header when using Authhetication API for authentication only

- added a couple of tests to AuthClientTest.py to test this...

$ nosetests ./tests/AuthClientTest.py
....
----------------------------------------------------------------------
Ran 4 tests in 0.001s

OK