### PR TITLE
Add profile for saml roles and more users info

### DIFF
--- a/okta/AppInstanceClient.py
+++ b/okta/AppInstanceClient.py
@@ -122,3 +122,22 @@ class AppInstanceClient(ApiClient):
         :return: None
         """
         ApiClient.post_path(self, '/{0}/lifecycle/deactivate'.format(id), None)
+
+    def list_applications_assigned_to_user(self, uid):
+        """Get a user group
+        :param uid: the user id or login
+        :type uid: str
+        :rtype: User
+        """
+        response = ApiClient.get_path(self, '?filter=user.id+eq+"{0}"&limit=40&expand=user/{0}'.format(uid))
+        return Utils.deserialize(response.text, AppInstance)
+
+
+    def get_assigned_user_for_application(self, uid, app_instance):
+        """Get a user group
+        :param uid: the user id or login
+        :type uid: str
+        :rtype: User
+        """
+        response = ApiClient.get_path(self, '/{0}/users/{1}'.format(app_instance.id, uid))
+        return Utils.deserialize(response.text, AppInstance)

--- a/okta/UsersClient.py
+++ b/okta/UsersClient.py
@@ -243,3 +243,31 @@ class UsersClient(ApiClient):
         """
         response = ApiClient.post_path(self, '/{0}/lifecycle/reset_factors'.format(uid))
         return Utils.deserialize(response.text, User)
+
+    def list_roles_assigned_to_user(self, uid):
+        """Get a user group
+        :param uid: the user id or login
+        :type uid: str
+        :rtype: User
+        """
+        response = ApiClient.get_path(self, '/{0}/roles'.format(uid))
+        return Utils.deserialize(response.text, User)
+
+    def get_user_member_in_groups(self, uid):
+        """Get a user group
+        :param uid: the user id or login
+        :type uid: str
+        :rtype: User
+        """
+        response = ApiClient.get_path(self, '/{0}/groups'.format(uid))
+        return Utils.deserialize(response.text, User)
+
+    def get_user_id(self, user_name):
+        """Get a user group
+        :param uid: the user id or login
+        :type uid: str
+        :rtype: User
+        """
+        response = ApiClient.get_path(self, '/{0}/'.format(user_name))
+        return Utils.deserialize(response.text, User)
+

--- a/okta/models/app/AppInstance.py
+++ b/okta/models/app/AppInstance.py
@@ -21,7 +21,9 @@ class AppInstance:
         'accessibility': Accessibility,
         'visibility': Visibility,
         'credentials': AppCredentials,
-        'settings': Settings
+        'settings': Settings,
+        'profile': str
+
     }
 
     def __init__(self):
@@ -60,6 +62,9 @@ class AppInstance:
         self.credentials = None  # AppCredentials
 
         self.settings = None  # Settings
+
+        self.profile = None  # profile Info
+
 
     @staticmethod
     def build_bookmark(url, label=None, request_integration=False):


### PR DESCRIPTION
Noam Greenberg  noam.greenebrg@gmail.com-NOSPAM
this fix or adds used in matomy media group for in app use 


Add the the option to see Profile info e.g ( Email , user name , Ids .... ) 
the issue use if you want to know what roles user have e.g in amazon 
you need this fix 

in the debuger you will see that you get only the " master" role that the user have but if you use samlRoles you will not see or only one so i add in the class  okta--> models -->app --> AppInstance.py
types = {
        'profile': str
}  # add it 

    def __init__(self):
   self.profile = None  # profile Info

and i add some function to use it 
