### PR TITLE
Adds support to create passwordless users with an Auth Provider

### DIFF
--- a/okta/UsersClient.py
+++ b/okta/UsersClient.py
@@ -75,7 +75,7 @@ class UsersClient(ApiClient):
         response = ApiClient.put_path(self, '/{0}'.format(uid), user)
         return Utils.deserialize(response.text, User)
 
-    def create_user(self, user, activate=None):
+    def create_user(self, user, activate=None, provider=None):
         """Create a user
 
         :param user: the data to create a user
@@ -84,12 +84,15 @@ class UsersClient(ApiClient):
         :type activate: bool
         :rtype: User
         """
-        if activate is None:
+        if activate is None and provider is None:
             response = ApiClient.post_path(self, '/', user)
         else:
-            params = {
-                'activate': activate
-            }
+            params = {}
+            if activate is not None:
+                params['activate'] = activate
+            if provider is not None:
+                params['provider'] = provider
+
             response = ApiClient.post_path(self, '/', user, params=params)
         return Utils.deserialize(response.text, User)
 

--- a/okta/UsersClient.py
+++ b/okta/UsersClient.py
@@ -82,6 +82,8 @@ class UsersClient(ApiClient):
         :type user: User
         :param activate: whether to activate the user
         :type activate: bool
+        :param provider: whether to create a passwordless user
+        :type provider: bool
         :rtype: User
         """
         if activate is None and provider is None:
@@ -94,6 +96,7 @@ class UsersClient(ApiClient):
                 params['provider'] = provider
 
             response = ApiClient.post_path(self, '/', user, params=params)
+        
         return Utils.deserialize(response.text, User)
 
     def delete_user(self, uid):

--- a/okta/models/user/User.py
+++ b/okta/models/user/User.py
@@ -29,6 +29,9 @@ class User:
         '_links': 'links'
     }
 
+    def __str__(self):
+        return f'<User provider={self.credentials.provider.type}>'
+
     def __init__(self, **kwargs):
 
         # unique key for user


### PR DESCRIPTION
In order to create passwordless users that can be authenticated using an Authentication Provider you need to POST to the user's endpoint with the param `provider=true` as a query string. If that param is not send the user is created in a "password reset" state and an email is sent to him asking to set his password, and that's not what we want when using an IDP.

This PR adds this optional param to send the `provider` param to the API.

Reference: https://developer.okta.com/docs/api/resources/users#create-user-with-authentication-provider