### PR TITLE
Fix - Add data for Create User Request

### DIFF
--- a/okta/http_client.py
+++ b/okta/http_client.py
@@ -47,8 +47,10 @@ class HTTPClient:
             # Prepare request parameters
             params = {'method': request['method'],
                       'url': request['url'],
-                      'headers': self._default_headers}
+                      'headers': self._default_headers,
+                      'data': json.dumps(request['data'])}
             json_data = request.get('json')
+            
             # empty json param may cause issue, so include it if needed only
             # more details: https://github.com/okta/okta-sdk-python/issues/131
             if json_data:

--- a/okta/http_client.py
+++ b/okta/http_client.py
@@ -50,7 +50,6 @@ class HTTPClient:
                       'headers': self._default_headers,
                       'data': json.dumps(request['data'])}
             json_data = request.get('json')
-            
             # empty json param may cause issue, so include it if needed only
             # more details: https://github.com/okta/okta-sdk-python/issues/131
             if json_data:


### PR DESCRIPTION
Create User was failing (even when following Read Me instructions exactly), because data wasn't being included in the request sent to Okta via okta.http_client. Updated to include request data as JSON for POST requests.

GET requests without data will be added to parameters as an empty object, but verified that these requests continue to go through successfully.

 