### PR TITLE
Add env variable to mock/unmock api calls. OKTA-347119

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+By default integration tests don't query real Okta API.
+To query real API env varialbe `MOCK_TESTS` should be present and set to 'False' in any case.
+Additionally, provide orgUrl and creds via env variable. Example:
+
+```sh
+export MOCK_TESTS=false
+export OKTA_CLIENT_ORG_URL="https://{testOktaDomain}"
+export OKTA_CLIENT_TOKEN="{testToken}"
+
+pytest tests/integration/
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,20 @@ PYTEST_MOCK_CLIENT = "pytest_mock_client"
 PYTEST_RE_RECORD = "record_mode"
 MOCK_TESTS = 'MOCK_TESTS'
 
+def is_mock_tests_flag_true():
+    """Return True by default, i.e. variable is not set.
+    Return False if env variable `MOCK_TESTS` is set to `false`, `FALSE`, etc.
+    Return True in all other cases.
+    """
+    return os.environ.get('MOCK_TESTS', 'true').strip().lower() != 'false'
+
+
 
 # Override vcr fixture from pytest_recording library
 @pytest.fixture(autouse=True)
 def vcr(request, vcr_markers, vcr_cassette_dir, record_mode, pytestconfig):
     """Install a cassette if a test is marked with `pytest.mark.vcr`."""
-    if vcr_markers and MOCK_TESTS not in os.environ:
+    if vcr_markers and is_mock_tests_flag_true():
         config = request.getfixturevalue("vcr_config")
         default_cassette = request.getfixturevalue("default_cassette_name")
         with use_cassette(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,13 @@ PYTEST_MOCK_CLIENT = "pytest_mock_client"
 PYTEST_RE_RECORD = "record_mode"
 MOCK_TESTS = 'MOCK_TESTS'
 
+
 def is_mock_tests_flag_true():
     """Return True by default, i.e. variable is not set.
     Return False if env variable `MOCK_TESTS` is set to `false`, `FALSE`, etc.
     Return True in all other cases.
     """
     return os.environ.get('MOCK_TESTS', 'true').strip().lower() != 'false'
-
 
 
 # Override vcr fixture from pytest_recording library

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,35 @@ import pytest
 import re
 import os
 
+from pytest_recording._vcr import use_cassette
+
 TEST_OKTA_URL = "test"
 B_TEST_OKTA_URL = b"test"
 URL_REGEX = r"dev-\d+"
 B_URL_REGEX = rb"dev-\d+"
 PYTEST_MOCK_CLIENT = "pytest_mock_client"
 PYTEST_RE_RECORD = "record_mode"
+MOCK_TESTS = 'MOCK_TESTS'
+
+
+# Override vcr fixture from pytest_recording library
+@pytest.fixture(autouse=True)
+def vcr(request, vcr_markers, vcr_cassette_dir, record_mode, pytestconfig):
+    """Install a cassette if a test is marked with `pytest.mark.vcr`."""
+    if vcr_markers and MOCK_TESTS not in os.environ:
+        config = request.getfixturevalue("vcr_config")
+        default_cassette = request.getfixturevalue("default_cassette_name")
+        with use_cassette(
+            default_cassette,
+            vcr_cassette_dir,
+            record_mode,
+            vcr_markers,
+            config,
+            pytestconfig
+        ) as cassette:
+            yield cassette
+    else:
+        yield None
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -7,7 +7,7 @@ import json
 from yarl import URL
 import datetime as dt
 import multidict
-from tests.conftest import PYTEST_MOCK_CLIENT
+from tests.conftest import PYTEST_MOCK_CLIENT, is_mock_tests_flag_true
 import os
 import time
 
@@ -37,6 +37,8 @@ class MockOktaClient(Client):
             fs.pause()
             super().__init__()
             fs.resume()
+        elif not is_mock_tests_flag_true():
+            super().__init__()
         else:
             super().__init__(CLIENT_CONFIG)
 


### PR DESCRIPTION
To unmock api calls set the following env variables:

```run_tests.sh

export OKTA_CLIENT_ORG_URL="{YOUR_ORG_URL}"
export OKTA_CLIENT_TOKEN="{YOUR_TOKEN}"
# set the following two to any value, just need to be present
export MOCK_TESTS=True
export pytest_mock_client=True
# run tests
pytest tests/integration/