### PR TITLE
Remove dependency on asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncio
 aiohttp
 flatdict
 pyyaml


### PR DESCRIPTION
This will close #157 and related to #144 
We should not use the asyncio from pip package after python 3.3.
It has already been maintained in the python standard library instead.
Especially the minimum python version for this library is 3.6.