### PR TITLE
Make dynamic enum for signOnMode. OKTA-369792

### DIFF
--- a/okta/models/application_sign_on_mode.py
+++ b/okta/models/application_sign_on_mode.py
@@ -18,28 +18,32 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import Enum, extend_enum
 
 
 class ApplicationSignOnMode(
     str,
-    MultiValueEnum
+    Enum
 ):
     """
     An enumeration class for ApplicationSignOnMode.
     """
 
-    BOOKMARK = "BOOKMARK", "bookmark"
-    BASIC_AUTH = "BASIC_AUTH", "basic_auth"
-    BROWSER_PLUGIN = "BROWSER_PLUGIN", "browser_plugin"
-    SECURE_PASSWORD_STORE = "SECURE_PASSWORD_STORE", "secure_password_store"
-    AUTO_LOGIN = "AUTO_LOGIN", "auto_login"
-    WS_FEDERATION = "WS_FEDERATION", "ws_federation"
-    SAML_2_0 = "SAML_2_0", "saml_2_0"
-    OPENID_CONNECT = "OPENID_CONNECT", "openid_connect"
-    SAML_1_1 = "SAML_1_1", "saml_1_1"
-    CUSTOM = "CUSTOM", "custom"
+    BOOKMARK = "BOOKMARK"
+    BASIC_AUTH = "BASIC_AUTH"
+    BROWSER_PLUGIN = "BROWSER_PLUGIN"
+    SECURE_PASSWORD_STORE = "SECURE_PASSWORD_STORE"
+    AUTO_LOGIN = "AUTO_LOGIN"
+    WS_FEDERATION = "WS_FEDERATION"
+    SAML_2_0 = "SAML_2_0"
+    OPENID_CONNECT = "OPENID_CONNECT"
+    SAML_1_1 = "SAML_1_1"
 
     @classmethod
     def _missing_(cls, value):
-        return ApplicationSignOnMode.CUSTOM
+        value_upper_case = value.upper()
+        try:
+            return getattr(cls, value_upper_case)
+        except:
+            extend_enum(ApplicationSignOnMode, value_upper_case, value_upper_case)
+            return getattr(cls, value_upper_case)

--- a/openapi/templates/model.py.hbs
+++ b/openapi/templates/model.py.hbs
@@ -2,6 +2,31 @@
 {{> partials.copyrightHeader }}
 {{#if (ne model.enum undefined)}}
 
+{{#if (eq model.modelName "ApplicationSignOnMode")}}
+from aenum import Enum, extend_enum
+
+
+class {{pascalCase model.modelName}}(
+    {{model.type}},
+    Enum
+):
+    """
+    An enumeration class for {{pascalCase model.modelName}}.
+    """
+
+    {{#each model.enum as |enum|}}
+    {{{replaceColons (upperCase (snakeCase enum))}}} = "{{enum}}"
+    {{/each}}
+
+    @classmethod
+    def _missing_(cls, value):
+        value_upper_case = value.upper()
+        try:
+            return getattr(cls, value_upper_case)
+        except:
+            extend_enum(ApplicationSignOnMode, value_upper_case, value_upper_case)
+            return getattr(cls, value_upper_case)
+{{else}}
 from aenum import MultiValueEnum
 
 
@@ -16,13 +41,7 @@ class {{pascalCase model.modelName}}(
     {{#each model.enum as |enum|}}
     {{{replaceColons (upperCase (snakeCase enum))}}} = "{{enum}}", "{{oppositeCase enum}}"
     {{/each}}
-    {{#if (eq model.modelName "ApplicationSignOnMode")}}
-    CUSTOM = "CUSTOM", "custom"
-
-    @classmethod
-    def _missing_(cls, value):
-        return ApplicationSignOnMode.CUSTOM
-    {{/if}}
+{{/if}}
 {{else}}
 
 {{#if (ne model.extends undefined)}}

--- a/tests/unit/test_sign_on_modes.py
+++ b/tests/unit/test_sign_on_modes.py
@@ -211,7 +211,7 @@ def test_unknown_sign_on_mode():
     response = copy.deepcopy(SAML_APP_RESP_DICT)
     response["signOnMode"] = "UNKNOWN_SIGN_ON_MODE"
     expected = copy.deepcopy(EXPECTED_SAML_APP_AS_DICT)
-    expected["signOnMode"] = ApplicationSignOnMode.CUSTOM
+    expected["signOnMode"] = ApplicationSignOnMode("UNKNOWN_SIGN_ON_MODE")
     expected["settings"] = {
         "app": {},
         "notifications": {


### PR DESCRIPTION
How this single value Enum simulates MultiValueEnum:

```py
class MockMultiValueEnum(str, Enum):
    VALUE_1 = 'value_1'
    VALUE_2 = 'value_2'
    VALUE_3 = 'value_3'

    @classmethod
    def _missing_(cls, value):
        try:
            return getattr(cls, value.upper())
        except:
            extend_enum(MockMultiValueEnum, value.upper(), value.lower())
            return getattr(cls, value.upper())
            
print(repr(MockMultiValueEnum('value_4')))   # lowercase
print(repr(MockMultiValueEnum('VALUE_4'))) # uppercase
print(repr(MockMultiValueEnum('value_5')))   # lowercase
print(repr(MockMultiValueEnum('VALUE_5'))) # uppercase
```
Output:
```
<MockMultiValueEnum.VALUE_4: 'value_4'>
<MockMultiValueEnum.VALUE_4: 'value_4'>
<MockMultiValueEnum.VALUE_5: 'value_5'>
<MockMultiValueEnum.VALUE_5: 'value_5'>
```