### PR TITLE
Fixing get_access_token to return tuple when access_token already exists

### DIFF
--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -37,7 +37,7 @@ class OAuth:
         """
         # Return token if already generated
         if self._access_token:
-            return self._access_token
+            return (self._access_token, None)
 
         # Otherwise create new one
         # Get JWT and create parameters for new Oauth token


### PR DESCRIPTION
Fix to ensure that the expected two item tuple format is returned by get_access_token when a client has an existing access_token cached. Was causing issues with calls to clear_user_sessions without this fix.