### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ async def main():
         except:
             print('User has no customAttr')
 
-
-asyncio.run(main())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
 ```
 Output should look like the following (removed pre-existing users from output):
 ```sh
@@ -459,7 +459,8 @@ async def main():
     print(client.get_custom_headers())
 
 
-asyncio.run(main())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
 ```
 
 Note, that custom headers will be overwritten with default headers with the same name.
@@ -703,7 +704,8 @@ async def main():
         print(err)
 
 
-asyncio.run(main())
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
 ```
 Result should look like:
 ```py


### PR DESCRIPTION
the aiohttp docs https://docs.aiohttp.org/en/stable/ say to use:
```python
loop = asyncio.get_event_loop()
loop.run_until_complete(main())
```

instead of `asyncio.run(main())`. if you don't, you get an error in Windows