### PR TITLE
Return tuple from get_access_token()

### DIFF
--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -37,7 +37,7 @@ class OAuth:
         """
         # Return token if already generated
         if self._access_token:
-            return self._access_token
+            return (self._access_token, None)
 
         # Otherwise create new one
         # Get JWT and create parameters for new Oauth token


### PR DESCRIPTION
In this Pull Request I correct a type of return value from oauth.py, get_access_token().

In request_executor.py function `create_request()` expects a tuple from `self._oauth.get_access_token()`
```
access_token, error = await self._oauth.get_access_token()
```
However in one specific case `get_access_token()` returns a string:

```
# Return token if already generated
if self._access_token:
    return self._access_token
```

Which causes an exception: 

>  File "site-packages/okta/request_executor.py", line 103, in create_request
    access_token, error = await self._oauth.get_access_token()
ValueError: too many values to unpack (expected 2)



