### PR TITLE
Add __getstate__ to allow for pickling

### DIFF
--- a/okta/models/user_profile.py
+++ b/okta/models/user_profile.py
@@ -210,6 +210,9 @@ class UserProfile(
         parent_req_format.update(current_obj_format)
         return parent_req_format
 
+    def __getstate__(self):
+        return vars(self)
+
     def __getattr__(self, attr_name):
         """
         Try different cases for backward compatibility.


### PR DESCRIPTION
The addition of __getattr__ fixed https://oktainc.atlassian.net/browse/OKTA-384293, breaks pickling of user objects. This is because pickle will attempt to check if the object has the __getstate__ method. Because the class doesn't define __getstate__ and now defined __getattr__ it will be called with __getstate__ as the attr_name. This will cause an issue beause attr_name is passed to okta/helpers.py line 42, `to_lower_camel_case()` which performs a lookup on a that attr_name split by '_'. 

The remaining code assumes that there is a string of length > 0 which is incorrect in the __getstate__ scenario which behaves as follows:
> ['', '', 'getstate', '', '']
> components[0][0].lower()
> IndexError
 
There are two solutions to resolve this, the easiest is specifying a __getstate__ function such that the invalid assumption of the content of components[0] is never made.