### PR TITLE
Make sign_on_mode of all apps instance of enum

### DIFF
--- a/okta/models/auto_login_application.py
+++ b/okta/models/auto_login_application.py
@@ -24,6 +24,7 @@ from okta.models import scheme_application_credentials\
     as scheme_application_credentials
 from okta.models import auto_login_application_settings\
     as auto_login_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class AutoLoginApplication(
@@ -36,7 +37,7 @@ class AutoLoginApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "AUTO_LOGIN"
+            self.sign_on_mode = ApplicationSignOnMode("AUTO_LOGIN")
             if "credentials" in config:
                 if isinstance(config["credentials"],
                               scheme_application_credentials.SchemeApplicationCredentials):

--- a/okta/models/basic_auth_application.py
+++ b/okta/models/basic_auth_application.py
@@ -24,6 +24,7 @@ from okta.models import scheme_application_credentials\
     as scheme_application_credentials
 from okta.models import basic_application_settings\
     as basic_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class BasicAuthApplication(
@@ -36,7 +37,7 @@ class BasicAuthApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "BASIC_AUTH"
+            self.sign_on_mode = ApplicationSignOnMode("BASIC_AUTH")
             if "credentials" in config:
                 if isinstance(config["credentials"],
                               scheme_application_credentials.SchemeApplicationCredentials):

--- a/okta/models/bookmark_application.py
+++ b/okta/models/bookmark_application.py
@@ -22,6 +22,7 @@ from okta.models.application\
     import Application
 from okta.models import bookmark_application_settings\
     as bookmark_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class BookmarkApplication(
@@ -34,7 +35,7 @@ class BookmarkApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "BOOKMARK"
+            self.sign_on_mode = ApplicationSignOnMode("BOOKMARK")
             self.name = config["name"]\
                 if "name" in config else "bookmark"
             if "settings" in config:

--- a/okta/models/browser_plugin_application.py
+++ b/okta/models/browser_plugin_application.py
@@ -22,6 +22,7 @@ from okta.models.application\
     import Application
 from okta.models import scheme_application_credentials\
     as scheme_application_credentials
+from okta.models import ApplicationSignOnMode
 
 
 class BrowserPluginApplication(
@@ -34,7 +35,7 @@ class BrowserPluginApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "BROWSER_PLUGIN"
+            self.sign_on_mode = ApplicationSignOnMode("BROWSER_PLUGIN")
             if "credentials" in config:
                 if isinstance(config["credentials"],
                               scheme_application_credentials.SchemeApplicationCredentials):

--- a/okta/models/open_id_connect_application.py
+++ b/okta/models/open_id_connect_application.py
@@ -24,6 +24,7 @@ from okta.models import o_auth_application_credentials\
     as o_auth_application_credentials
 from okta.models import open_id_connect_application_settings\
     as open_id_connect_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class OpenIdConnectApplication(
@@ -36,7 +37,7 @@ class OpenIdConnectApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "OPENID_CONNECT"
+            self.sign_on_mode = ApplicationSignOnMode("OPENID_CONNECT")
             if "credentials" in config:
                 if isinstance(config["credentials"],
                               o_auth_application_credentials.OAuthApplicationCredentials):

--- a/okta/models/saml_application.py
+++ b/okta/models/saml_application.py
@@ -22,6 +22,7 @@ from okta.models.application\
     import Application
 from okta.models import saml_application_settings\
     as saml_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class SamlApplication(
@@ -34,7 +35,7 @@ class SamlApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "SAML_2_0"
+            self.sign_on_mode = ApplicationSignOnMode("SAML_2_0")
             if "settings" in config:
                 if isinstance(config["settings"],
                               saml_application_settings.SamlApplicationSettings):

--- a/okta/models/secure_password_store_application.py
+++ b/okta/models/secure_password_store_application.py
@@ -24,6 +24,7 @@ from okta.models import scheme_application_credentials\
     as scheme_application_credentials
 from okta.models import secure_password_store_application_settings\
     as secure_password_store_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class SecurePasswordStoreApplication(
@@ -36,7 +37,7 @@ class SecurePasswordStoreApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "SECURE_PASSWORD_STORE"
+            self.sign_on_mode = ApplicationSignOnMode("SECURE_PASSWORD_STORE")
             if "credentials" in config:
                 if isinstance(config["credentials"],
                               scheme_application_credentials.SchemeApplicationCredentials):

--- a/okta/models/ws_federation_application.py
+++ b/okta/models/ws_federation_application.py
@@ -22,6 +22,7 @@ from okta.models.application\
     import Application
 from okta.models import ws_federation_application_settings\
     as ws_federation_application_settings
+from okta.models import ApplicationSignOnMode
 
 
 class WsFederationApplication(
@@ -34,7 +35,7 @@ class WsFederationApplication(
     def __init__(self, config=None):
         super().__init__(config)
         if config:
-            self.sign_on_mode = "WS_FEDERATION"
+            self.sign_on_mode = ApplicationSignOnMode("WS_FEDERATION")
             self.name = config["name"]\
                 if "name" in config else "template_wsfed"
             if "settings" in config:

--- a/openapi/templates/model.py.hbs
+++ b/openapi/templates/model.py.hbs
@@ -64,6 +64,9 @@ from okta.okta_collection import OktaCollection
 from okta.models import {{snakeCase type}}\
     as {{snakeCase type}}
 {{/each}}
+{{#if (ne model.signOnMode undefined)}}
+from okta.models import ApplicationSignOnMode
+{{/if}}
 
 
 class {{pascalCase model.modelName}}(
@@ -95,7 +98,7 @@ class {{pascalCase model.modelName}}(
         {{#if (gt model.properties.length 0)}}
         if config:
             {{#if (ne model.signOnMode undefined)}}
-            self.sign_on_mode = "{{model.signOnMode}}"
+            self.sign_on_mode = ApplicationSignOnMode("{{model.signOnMode}}")
             {{/if}}
             {{#if (ne model.factorType undefined)}}
             self.factor_type = "{{model.factorType}}"


### PR DESCRIPTION
Related to #198 
This approach doesn't brake existing tests, for example this still works (tests/integration/test_applications_it.py, test_create_bookmark_app):
```py
found_app, _, err = await client.get_application(app.id)
assert err is None
assert found_app.label == APP_LABEL
assert found_app.sign_on_mode == models.ApplicationSignOnMode.BOOKMARK
```
Also, given enum comparable with strings:
```py
>>> models.ApplicationSignOnMode.BOOKMARK == 'BOOKMARK'
True
```