### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,20 +50,20 @@ $ git commit -m "descriptive commit message for your changes"
 Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
 In order to make changes in models and/or resource clients you need to determine what is the root of changes:
 1. if change is needed because of new version of openapi spec has been released, then:
-    1.1. get specific openapi spec version (v2.7.1 in the following example):
+   1.1. get specific openapi spec version (v2.7.1 in the following example):
   ```sh
   cd openapi
   npm install @okta/openapi@2.7.1
   ```
   or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
-    1.2. re-generate okta-sdk-python (in openapi directory):
+   1.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```
 
 2. if change isn't related to new openapi spec version, for example, update template for models, then:
-    2.1. edit needed templates under `openapi/templates` directory
-    2.2. re-generate okta-sdk-python (in openapi directory):
+   2.1. edit needed templates under `openapi/templates` directory
+   2.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,19 +50,23 @@ $ git commit -m "descriptive commit message for your changes"
 Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
 In order to make changes in models and/or resource clients you need to determine what is the root of changes:
 1. if change is needed because of new version of openapi spec has been released, then:
+
    1.1. get specific openapi spec version (v2.7.1 in the following example):
   ```sh
   cd openapi
   npm install @okta/openapi@2.7.1
   ```
   or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
+
    1.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```
 
 2. if change isn't related to new openapi spec version, for example, update template for models, then:
+
    2.1. edit needed templates under `openapi/templates` directory
+
    2.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,29 @@ $ git commit -m "descriptive commit message for your changes"
 
 > The `-b` specifies that you want to create a new branch called `feature_x`. You only specify `-b` the first time you checkout because you are creating a new branch. Once the `feature_x` branch exists, you can later switch to it with only `git checkout feature_x`.
 
+## Generate models and resource clients
+
+Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
+In order to make changes in models and/or resource clients you need to determine what is the root of changes:
+1) if change is needed because of new version of openapi spec has been released, then:
+  1.1) get specific openapi spec version (v2.7.1 in the following example):
+  ```sh
+  cd openapi
+  npm install @okta/openapi@2.7.1
+  ```
+  or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
+  1.2) re-generate okta-sdk-python (in openapi directory):
+  ```sh
+  yarn build
+  ```
+
+2) if change isn't related to new openapi spec version, for example, update template for models, then:
+  2.1) edit needed templates under `openapi/templates` directory
+  2.2) re-generate okta-sdk-python (in openapi directory):
+  ```sh
+  yarn build
+  ```
+
 ## Adding/Changing Tests
 
 All tests must continue to pass when changes are made. `pytest` is used as the testing framework for this SDK. Run the following to ensure your change hasn't broken anything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,21 +49,21 @@ $ git commit -m "descriptive commit message for your changes"
 
 Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
 In order to make changes in models and/or resource clients you need to determine what is the root of changes:
-1) if change is needed because of new version of openapi spec has been released, then:
-  1.1) get specific openapi spec version (v2.7.1 in the following example):
+1. if change is needed because of new version of openapi spec has been released, then:
+  i. get specific openapi spec version (v2.7.1 in the following example):
   ```sh
   cd openapi
   npm install @okta/openapi@2.7.1
   ```
   or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
-  1.2) re-generate okta-sdk-python (in openapi directory):
+  ii. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```
 
-2) if change isn't related to new openapi spec version, for example, update template for models, then:
-  2.1) edit needed templates under `openapi/templates` directory
-  2.2) re-generate okta-sdk-python (in openapi directory):
+2. if change isn't related to new openapi spec version, for example, update template for models, then:
+  i. edit needed templates under `openapi/templates` directory
+  ii. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,20 +50,20 @@ $ git commit -m "descriptive commit message for your changes"
 Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
 In order to make changes in models and/or resource clients you need to determine what is the root of changes:
 1. if change is needed because of new version of openapi spec has been released, then:
-  i. get specific openapi spec version (v2.7.1 in the following example):
+    1.1. get specific openapi spec version (v2.7.1 in the following example):
   ```sh
   cd openapi
   npm install @okta/openapi@2.7.1
   ```
   or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
-  ii. re-generate okta-sdk-python (in openapi directory):
+    1.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```
 
 2. if change isn't related to new openapi spec version, for example, update template for models, then:
-  i. edit needed templates under `openapi/templates` directory
-  ii. re-generate okta-sdk-python (in openapi directory):
+    2.1. edit needed templates under `openapi/templates` directory
+    2.2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,25 +49,26 @@ $ git commit -m "descriptive commit message for your changes"
 
 Models and resource clients are auto-generated in accordance with specific openapi spec version https://github.com/okta/okta-management-openapi-spec.
 In order to make changes in models and/or resource clients you need to determine what is the root of changes:
-1. if change is needed because of new version of openapi spec has been released, then:
 
-   1.1. get specific openapi spec version (v2.7.1 in the following example):
+### if change is needed because of new version of openapi spec has been released, then:
+
+   1. get specific openapi spec version (v2.7.1 in the following example):
   ```sh
   cd openapi
   npm install @okta/openapi@2.7.1
   ```
   or copy file `https://github.com/okta/okta-management-openapi-spec/blob/master/dist/spec.json` to `openapi/node_modules/@okta/openapi/dist/spec.json` (in order to get specific version of a file use release tags or clone repo and checkout specific commit)
 
-   1.2. re-generate okta-sdk-python (in openapi directory):
+   2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```
 
-2. if change isn't related to new openapi spec version, for example, update template for models, then:
+### if change isn't related to new openapi spec version, for example, update template for models, then:
 
-   2.1. edit needed templates under `openapi/templates` directory
+   1. edit needed templates under `openapi/templates` directory
 
-   2.2. re-generate okta-sdk-python (in openapi directory):
+   2. re-generate okta-sdk-python (in openapi directory):
   ```sh
   yarn build
   ```


### PR DESCRIPTION
This PR solves the problem when 3rd party contributors don't know how to deal with auto-generated files properly.
Related issue: https://github.com/okta/okta-sdk-python/issues/243

Added new section to CONTRIBUTING.md: https://github.com/okta/okta-sdk-python/blob/update-contributing-guide/CONTRIBUTING.md#generate-models-and-resource-clients
<img width="1206" alt="Screenshot 2021-10-04 at 16 42 23" src="https://user-images.githubusercontent.com/73126645/135862864-f588267d-230c-4fae-bec6-c4771247d66e.png">

