### PR TITLE
Allow custom ssl context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,28 @@ Each one of the configuration values above can be turned into an environment var
 - `OKTA_CLIENT_RATELIMIT_MAXRETRIES`
 - `OKTA_TESTING_TESTINGDISABLEHTTPSCHECK`
 
+### Other configuration options
+
+Starting with SDK v2.3.0 you can provide custom SSL context:
+
+```py
+import asyncio
+import ssl
+
+from okta.client import Client as OktaClient
+
+
+async def main():
+    # create default context for demo purpose
+    ssl_context = ssl.create_default_context()
+    client = OktaClient({"sslContext": ssl_context})
+    users, resp, err = await client.list_users()
+    print(users)
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
+```
+
 ## Rate Limiting
 
 The Okta API will return 429 responses if too many requests are made within a given time. Please see [Rate Limiting at Okta][rate-limiting-okta] for a complete list of which endpoints are rate limited. When a 429 error is received, the X-Rate-Limit-Reset header will tell you the time at which you can retry. This section discusses the method for handling rate limiting with this SDK.

--- a/okta/http_client.py
+++ b/okta/http_client.py
@@ -31,6 +31,10 @@ class HTTPClient:
             self._proxy = self._setup_proxy(http_config["proxy"])
         else:
             self._proxy = None
+        if "sslContext" in http_config:
+            self._ssl_context = http_config["sslContext"]
+        else:
+            self._ssl_context = None
 
     async def send_request(self, request):
         """
@@ -68,12 +72,15 @@ class HTTPClient:
                 params['timeout'] = self._timeout
             if self._proxy:
                 params['proxy'] = self._proxy
+            if self._ssl_context:
+                params['ssl_context'] = self._ssl_context
             # Fire request
-            async with aiohttp.request(**params) as response:
-                return (response.request_info,
-                        response,
-                        await response.text(),
-                        None)
+            async with aiohttp.ClientSession() as session:
+                async with session.request(**params) as response:
+                    return (response.request_info,
+                            response,
+                            await response.text(),
+                            None)
         except (aiohttp.ClientError, asyncio.TimeoutError) as error:
             # Return error if arises
             logger.exception(error)

--- a/okta/request_executor.py
+++ b/okta/request_executor.py
@@ -67,8 +67,8 @@ class RequestExecutor:
         self._http_client = http_client_impl({
             'requestTimeout': self._request_timeout,
             'headers': self._default_headers,
-            'proxy': self._config["client"]["proxy"] if "proxy"
-            in self._config["client"] else None
+            'proxy': self._config["client"].get("proxy"),
+            'sslContext': self._config["client"].get("sslContext")
         })
         HTTPClient.raise_exception = \
             self._config['client'].get("raiseException", False)

--- a/tests/unit/test_domains.py
+++ b/tests/unit/test_domains.py
@@ -181,7 +181,7 @@ class TestDomainResource:
                 return GET_DOMAIN_RESP
 
         mock_http_request = MockHTTPRequest()
-        monkeypatch.setattr(aiohttp, 'request', mock_http_request)
+        monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
 
         domain_resp, _, err = asyncio.run(client.get_domain('OcDz6iRyjkaCTXkdo0g3'))
         assert err is None
@@ -234,7 +234,7 @@ class TestDomainResource:
                 return MockHTTPRequest._mocked_response
 
         mock_http_request = MockHTTPRequest()
-        monkeypatch.setattr(aiohttp, 'request', mock_http_request)
+        monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
 
         domain_config = {
             "domain": "login.example.com",

--- a/tests/unit/test_request_executor.py
+++ b/tests/unit/test_request_executor.py
@@ -63,7 +63,7 @@ def test_retry_count_header(monkeypatch):
                    '"type": null}]'
 
     mock_http_request = MockHTTPRequest()
-    monkeypatch.setattr(aiohttp, 'request', mock_http_request)
+    monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
     res, resp_body, error = asyncio.run(client.list_users())
     # Check request was retried max times and header 'X-Okta-Retry-Count' was set properly
     assert mock_http_request.request_info['headers'].get('X-Okta-Retry-Count') == '2'

--- a/tests/unit/test_user_schema.py
+++ b/tests/unit/test_user_schema.py
@@ -84,7 +84,7 @@ class TestUserSchemaResource:
     @pytest.mark.asyncio
     async def test_get_application_user_schema(self, monkeypatch):
         mock_http_request = MockHTTPRequest()
-        monkeypatch.setattr(aiohttp, 'request', mock_http_request)
+        monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
 
         org_url = "https://test.okta.com"
         token = "TOKEN"
@@ -111,7 +111,7 @@ class TestUserSchemaResource:
     @pytest.mark.asyncio
     async def test_update_application_user_profile(self, monkeypatch):
         mock_http_request = MockHTTPRequest()
-        monkeypatch.setattr(aiohttp, 'request', mock_http_request)
+        monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
 
         org_url = "https://test.okta.com"
         token = "TOKEN"


### PR DESCRIPTION
This PR introduces new configuration option `sslContext`. Related to #255 

Usage example:

```py
import asyncio
import ssl

from okta.client import Client as OktaClient


async def main():
    # create default context for demo purpose
    ssl_context = ssl.create_default_context()
    client = OktaClient({"sslContext": ssl_context})
    users, resp, err = await client.list_users()
    print(users)


loop = asyncio.get_event_loop()
loop.run_until_complete(main())
```