### PR TITLE
Create python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,4 +37,4 @@ jobs:
         flake8 okta/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests/
+        pytest tests/integration

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 okta/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 okta/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10-dev"
 
 install:
   - pip install -U -r requirements.txt
@@ -17,15 +18,15 @@ jobs:
     - stage: test
       python: 3.8
       name: "Unit Tests"
-      script: 
+      script:
         - echo "Running unit tests..."
         - pytest tests/unit/
       name: "Integration Tests"
-      script: 
+      script:
         - echo "Running integration tests..."
         - pytest tests/integration/
     - stage: code_style_test
       name: "Flake8 Check"
-      script: 
+      script:
         - echo "Code Style check..."
         - "flake8 --extend-ignore=E501 okta/"

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -612,7 +612,11 @@ def test_constructor_invalid_port_number(port):
 def test_constructor_custom_http_client_impl():
     class CustomHTTPClient(HTTPClient):
         pass
-    config = {'httpClient': CustomHTTPClient}
+    org_url = "https://test.okta.com"
+    token = "TOKEN"
+    config = {'orgUrl': org_url,
+              'token': token,
+              'httpClient': CustomHTTPClient}
     client = OktaClient(config)
     assert isinstance(client._request_executor._http_client, CustomHTTPClient)
 
@@ -620,7 +624,11 @@ def test_constructor_custom_http_client_impl():
 def test_constructor_client_logging():
     logger = logging.getLogger('okta-sdk-python')
     assert logger.disabled
-    config = {'logging': {"enabled": True, "logLevel": logging.DEBUG}}
+    org_url = "https://test.okta.com"
+    token = "TOKEN"
+    config = {'orgUrl': org_url,
+              'token': token,
+              'logging': {"enabled": True, "logLevel": logging.DEBUG}}
     client = OktaClient(config)
     assert not logger.disabled
     assert logger.level == logging.DEBUG

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,15 +2,7 @@ import aiohttp
 import asyncio
 import logging
 from aiohttp.client_reqrep import ConnectionKey
-try:
-    from ssl import SSLCertVerificationError
-except ImportError:
-    # workaround for python 3.6
-    class SSLCertVerificationError:
-        def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
-
+from ssl import SSLCertVerificationError
 from okta.client import Client as OktaClient
 import pytest
 from okta.constants import FINDING_OKTA_DOMAIN

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,7 +2,14 @@ import aiohttp
 import asyncio
 import logging
 from aiohttp.client_reqrep import ConnectionKey
-from ssl import SSLCertVerificationError
+try:
+    from ssl import SSLCertVerificationError
+except ImportError:
+    # workaround for python 3.6
+    class SSLCertVerificationError:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
 
 from okta.client import Client as OktaClient
 import pytest


### PR DESCRIPTION
Setup GitHub actions for okta-sdk-python

This PR allow run only integration tests within GH action including python 3.6-3.10. Travis CI is configured for integration tests too. Unittests might fail on python 3.6, because they are written using new features, which aren't available in Python 3.6. Thus, we need to make some refactoring for unittests to allow it in GH actions and/or Travis