### PR TITLE
Add possibility to reuse http session. GH #267

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ Another way to instantiate okta_client (config should be provided in other place
 okta_client = OktaClient()
 ```
 
+Http session was introduced within v2.3.0 to allow custom SSL contest. Starting with SDK v2.4.0 you can reuse http session to gain better performance:
+
+```py
+import asyncio
+import aiohttp
+
+from okta.client import Client as OktaClient
+
+
+async def main():
+    async with OktaClient() as client:
+        # perform all queries within same session
+        users, okta_resp, err = await client.list_users()
+        user, okta_resp, err = await client.get_user(users[0].id)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
+```
+
+Context Manager is a preferable way to use OktaClient to perform bunch of API requests.
+
 > Using a Python dictionary to hard-code the Okta domain and API token is encouraged for development; In production, you should use a more secure way of storing these values. This library supports a few different configuration sources, covered in the [configuration reference](#configuration-reference) section.
 
 ### OAuth 2.0
@@ -1034,27 +1056,6 @@ async def main():
     client = OktaClient({"sslContext": ssl_context})
     users, resp, err = await client.list_users()
     print(users)
-
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
-```
-
-Http session was introduced within v2.3.0 to allow custom SSL contest. Starting with SDK v2.4.0 you can reuse http session to gain better performance:
-
-```py
-import okta.client
-import asyncio
-import aiohttp
-
-
-async def main():
-    async with aiohttp.ClientSession() as session:
-        client = okta.client.Client({"session": session})
-
-        # perform all queries within given session
-        users, okta_resp, err = await client.list_users()
-        user, okta_resp, err = await client.get_user(users[0].id)
-
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,27 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(main())
 ```
 
+Http session was introduced within v2.3.0 to allow custom SSL contest. Starting with SDK v2.4.0 you can reuse http session to gain better performance:
+
+```py
+import okta.client
+import asyncio
+import aiohttp
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        client = okta.client.Client({"session": session})
+
+        # perform all queries within given session
+        users, okta_resp, err = await client.list_users()
+        user, okta_resp, err = await client.get_user(users[0].id)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())
+```
+
 ## Rate Limiting
 
 The Okta API will return 429 responses if too many requests are made within a given time. Please see [Rate Limiting at Okta][rate-limiting-okta] for a complete list of which endpoints are rate limited. When a 429 error is received, the X-Rate-Limit-Reset header will tell you the time at which you can retry. This section discusses the method for handling rate limiting with this SDK.

--- a/okta/client.py
+++ b/okta/client.py
@@ -17,6 +17,7 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
+import aiohttp
 import logging
 
 from okta.config.config_setter import ConfigSetter
@@ -143,8 +144,7 @@ class Client(
             user_config.get("requestExecutor", RequestExecutor)(
                 self._config,
                 cache,
-                user_config.get("httpClient", None),
-                session=user_config.get("session"))
+                user_config.get("httpClient", None))
 
         # set private key variables
         if self._authorization_mode == 'PrivateKey':
@@ -157,6 +157,17 @@ class Client(
         if self._config["client"]["logging"]["enabled"] is True:
             logger = logging.getLogger('okta-sdk-python')
             logger.disabled = False
+
+    async def __aenter__(self):
+        """Automatically create and set session within context manager."""
+        self._session = aiohttp.ClientSession()
+        self._request_executor.set_session(self._session)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Automatically close session within context manager."""
+        await self._session.close()
+
     """
     Getters
     """

--- a/okta/client.py
+++ b/okta/client.py
@@ -143,7 +143,8 @@ class Client(
             user_config.get("requestExecutor", RequestExecutor)(
                 self._config,
                 cache,
-                user_config.get("httpClient", None))
+                user_config.get("httpClient", None),
+                session=user_config.get("session"))
 
         # set private key variables
         if self._authorization_mode == 'PrivateKey':

--- a/okta/http_client.py
+++ b/okta/http_client.py
@@ -19,7 +19,7 @@ class HTTPClient:
     """
     raise_exception = False
 
-    def __init__(self, http_config={}, session=None):
+    def __init__(self, http_config={}):
         # Get headers from Request Executor
         self._default_headers = http_config["headers"]
         # Create timeout for all HTTP requests
@@ -35,7 +35,17 @@ class HTTPClient:
             self._ssl_context = http_config["sslContext"]
         else:
             self._ssl_context = None
+        self._session = None
+
+    def set_session(self, session):
+        """Set Client Session to improve performance by reusing session.
+
+        Session should be closed manually or within context manager.
+        """
         self._session = session
+
+    async def close_session(self):
+        await self._session.close()
 
     async def send_request(self, request):
         """

--- a/okta/request_executor.py
+++ b/okta/request_executor.py
@@ -21,7 +21,7 @@ class RequestExecutor:
     RETRY_COUNT_HEADER = 'X-Okta-Retry-Count'
     RETRY_FOR_HEADER = 'X-Okta-Retry-For'
 
-    def __init__(self, config, cache, http_client=None):
+    def __init__(self, config, cache, http_client=None, session=None):
         """
         Constructor for Request Executor object for Okta Client
 
@@ -68,8 +68,10 @@ class RequestExecutor:
             'requestTimeout': self._request_timeout,
             'headers': self._default_headers,
             'proxy': self._config["client"].get("proxy"),
-            'sslContext': self._config["client"].get("sslContext")
-        })
+            'sslContext': self._config["client"].get("sslContext"),
+        },
+            session=session
+        )
         HTTPClient.raise_exception = \
             self._config['client'].get("raiseException", False)
         self._custom_headers = {}

--- a/okta/request_executor.py
+++ b/okta/request_executor.py
@@ -21,7 +21,7 @@ class RequestExecutor:
     RETRY_COUNT_HEADER = 'X-Okta-Retry-Count'
     RETRY_FOR_HEADER = 'X-Okta-Retry-For'
 
-    def __init__(self, config, cache, http_client=None, session=None):
+    def __init__(self, config, cache, http_client=None):
         """
         Constructor for Request Executor object for Okta Client
 
@@ -69,9 +69,7 @@ class RequestExecutor:
             'headers': self._default_headers,
             'proxy': self._config["client"].get("proxy"),
             'sslContext': self._config["client"].get("sslContext"),
-        },
-            session=session
-        )
+        })
         HTTPClient.raise_exception = \
             self._config['client'].get("raiseException", False)
         self._custom_headers = {}
@@ -340,6 +338,9 @@ class RequestExecutor:
 
     def set_custom_headers(self, headers):
         self._custom_headers.update(headers)
+
+    def set_session(self, session):
+        self._http_client.set_session(session)
 
     def clear_custom_headers(self):
         self._custom_headers = {}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -892,3 +892,18 @@ def test_client_ssl_context(monkeypatch, mocker):
     asyncio.run(client.list_users())
 
     assert mock_http_request.request_info['ssl_context'] == mock_ssl_context
+
+
+def test_client_session(mocker):
+    org_url = "https://test.okta.com"
+    token = "TOKEN"
+    # no session
+    config = {'orgUrl': org_url, 'token': token}
+    client = OktaClient(config)
+    assert client._request_executor._http_client._session is None
+
+    # with session
+    session = mocker.Mock()
+    config = {'orgUrl': org_url, 'token': token, 'session': session}
+    client = OktaClient(config)
+    assert client._request_executor._http_client._session is session

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,6 @@
 import aiohttp
 import asyncio
+import aiohttp
 import logging
 from aiohttp.client_reqrep import ConnectionKey
 from ssl import SSLCertVerificationError
@@ -894,7 +895,8 @@ def test_client_ssl_context(monkeypatch, mocker):
     assert mock_http_request.request_info['ssl_context'] == mock_ssl_context
 
 
-def test_client_session(mocker):
+@pytest.mark.asyncio
+async def test_client_session(mocker):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     # no session
@@ -903,7 +905,6 @@ def test_client_session(mocker):
     assert client._request_executor._http_client._session is None
 
     # with session
-    session = mocker.Mock()
-    config = {'orgUrl': org_url, 'token': token, 'session': session}
-    client = OktaClient(config)
-    assert client._request_executor._http_client._session is session
+    config = {'orgUrl': org_url, 'token': token}
+    async with OktaClient(config) as client:
+        assert isinstance(client._request_executor._http_client._session, aiohttp.ClientSession)


### PR DESCRIPTION
Related to #267 
Add possibility to reuse http session by turning client into context manager (add `__aenter__` and `__aexit__`).
Using non-existent ids for testing purposes, performance tripled:
```py
import okta.client
import asyncio
import aiohttp

from time import time


async def main():
    n = 20
    # no_session
    start_time = time()
    client = okta.client.Client()
    for i in range(n):
        resp = await client.get_user(f'{i}')
    end_time = time()
    print(f'no session: {end_time-start_time} sec')

    # session
    start_time = time()
    async with okta.client.Client() as client:
        for i in range(n):
            resp = await client.get_user(f'{i}')
    end_time = time()
    print(f'session: {end_time-start_time} sec')

loop = asyncio.get_event_loop()
loop.run_until_complete(main())
```