### PR TITLE
Remove all explicit event loop usage. Use pytest.mark.asyncio decorator

### DIFF
--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlsplit, parse_qsl, urlencode, urlunsplit
-
 from okta.user_agent import UserAgent
 from okta.constants import DATETIME_FORMAT
 from okta.client import Client

--- a/tests/unit/test_applications_ut.py
+++ b/tests/unit/test_applications_ut.py
@@ -1,5 +1,4 @@
 import aiohttp
-import asyncio
 import json
 import pytest
 import okta.models as models

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,4 @@
 import aiohttp
-import asyncio
 import aiohttp
 import logging
 from aiohttp.client_reqrep import ConnectionKey
@@ -634,16 +633,18 @@ def test_constructor_client_logging():
     assert logger.level == logging.DEBUG
 
 
-def test_client_raise_exception():
+@pytest.mark.asyncio
+async def test_client_raise_exception():
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token, 'raiseException': True}
     client = OktaClient(config)
     with pytest.raises(HTTPException):
-        asyncio.run(client.list_users())
+        _ = await client.list_users()
 
 
-def test_client_custom_headers(monkeypatch, mocker):
+@pytest.mark.asyncio
+async def test_client_custom_headers(monkeypatch, mocker):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token}
@@ -679,7 +680,7 @@ def test_client_custom_headers(monkeypatch, mocker):
 
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
-    asyncio.run(client.list_users())
+    _ = await client.list_users()
     assert 'Header-Test-1' in mock_http_request.headers
     assert 'Header-Test-2' in mock_http_request.headers
 
@@ -688,7 +689,8 @@ def test_client_custom_headers(monkeypatch, mocker):
     assert client.get_custom_headers() == {}
 
 
-def test_client_handle_aiohttp_error(monkeypatch, mocker):
+@pytest.mark.asyncio
+async def test_client_handle_aiohttp_error(monkeypatch, mocker):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token}
@@ -720,13 +722,14 @@ def test_client_handle_aiohttp_error(monkeypatch, mocker):
 
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
-    res, resp_body, error = asyncio.run(client.list_users())
+    res, resp_body, error = await client.list_users()
     assert res is None
     assert resp_body is None
     assert isinstance(error, aiohttp.ClientError)
 
 
-def test_client_log_debug(monkeypatch, caplog):
+@pytest.mark.asyncio
+async def test_client_log_debug(monkeypatch, caplog):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token,
@@ -768,14 +771,15 @@ def test_client_log_debug(monkeypatch, caplog):
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
     with caplog.at_level(logging.DEBUG):
-        res, resp_body, error = asyncio.run(client.list_users())
+        res, resp_body, error = await client.list_users()
         assert 'okta-sdk-python' in caplog.text
         assert 'DEBUG' in caplog.text
         assert "'method': 'GET'" in caplog.text
         assert "'url': 'https://test.okta.com/api/v1/users'" in caplog.text
 
 
-def test_client_log_info(monkeypatch, caplog):
+@pytest.mark.asyncio
+async def test_client_log_info(monkeypatch, caplog):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token,
@@ -817,11 +821,12 @@ def test_client_log_info(monkeypatch, caplog):
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
     with caplog.at_level(logging.INFO):
-        res, resp_body, error = asyncio.run(client.list_users())
+        res, resp_body, error = await client.list_users()
         assert caplog.text == ''
 
 
-def test_client_log_exception(monkeypatch, caplog):
+@pytest.mark.asyncio
+async def test_client_log_exception(monkeypatch, caplog):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token,
@@ -855,11 +860,12 @@ def test_client_log_exception(monkeypatch, caplog):
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
     with caplog.at_level(logging.DEBUG):
-        res, resp_body, error = asyncio.run(client.list_users())
+        res, resp_body, error = await client.list_users()
         assert 'Cannot connect to host https://test.okta.com' in caplog.text
 
 
-def test_client_ssl_context(monkeypatch, mocker):
+@pytest.mark.asyncio
+async def test_client_ssl_context(monkeypatch, mocker):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     mock_ssl_context = mocker.MagicMock()
@@ -890,7 +896,7 @@ def test_client_ssl_context(monkeypatch, mocker):
 
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
-    asyncio.run(client.list_users())
+    _ = await client.list_users()
 
     assert mock_http_request.request_info['ssl_context'] == mock_ssl_context
 

--- a/tests/unit/test_domains.py
+++ b/tests/unit/test_domains.py
@@ -1,5 +1,5 @@
 import aiohttp
-import asyncio
+import pytest
 from okta.client import Client as OktaClient
 from okta.models import DnsRecord, DomainCertificate, DomainCertificateMetadata, Domain
 
@@ -149,7 +149,8 @@ class TestDomainResource:
     Unit Tests for the Domain Resource
     """
 
-    def test_get_domain(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_get_domain(self, monkeypatch):
         org_url = "https://test.okta.com"
         token = "TOKEN"
         config = {'orgUrl': org_url, 'token': token}
@@ -183,7 +184,7 @@ class TestDomainResource:
         mock_http_request = MockHTTPRequest()
         monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
 
-        domain_resp, _, err = asyncio.run(client.get_domain('OcDz6iRyjkaCTXkdo0g3'))
+        domain_resp, _, err = await client.get_domain('OcDz6iRyjkaCTXkdo0g3')
         assert err is None
         assert isinstance(domain_resp, Domain)
         assert isinstance(domain_resp.public_certificate, DomainCertificateMetadata)
@@ -192,7 +193,8 @@ class TestDomainResource:
             assert isinstance(dns_record, DnsRecord)
         assert domain_resp.domain == 'login.example.com'
 
-    def test_create_certificate_and_verify_domain(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_create_certificate_and_verify_domain(self, monkeypatch):
         org_url = "https://test.okta.com"
         token = "TOKEN"
         config = {'orgUrl': org_url, 'token': token}
@@ -240,15 +242,15 @@ class TestDomainResource:
             "domain": "login.example.com",
             "certificateSourceType": "MANUAL"
         }
-        domain_resp, _, err = asyncio.run(client.create_domain(domain_config))
+        domain_resp, _, err = await client.create_domain(domain_config)
         assert err is None
 
         cert = DomainCertificate({'type': 'PEM',
                                   'certificate': 'test_certificate',
                                   'privateKey': 'test_private_key'})
-        cert_resp, err = asyncio.run(client.create_certificate(domain_resp.id, cert))
+        cert_resp, err = await client.create_certificate(domain_resp.id, cert)
         assert err is None
 
-        domain_resp, _, err = asyncio.run(client.verify_domain(domain_resp.id))
+        domain_resp, _, err = await client.verify_domain(domain_resp.id)
         assert err is None
         assert domain_resp.validation_status == 'VERIFIED'

--- a/tests/unit/test_request_executor.py
+++ b/tests/unit/test_request_executor.py
@@ -1,5 +1,4 @@
 import aiohttp
-import asyncio
 import datetime
 import pytest
 import time
@@ -10,7 +9,8 @@ from okta.client import Client as OktaClient
 from okta.request_executor import RequestExecutor
 
 
-def test_retry_count_header(monkeypatch):
+@pytest.mark.asyncio
+async def test_retry_count_header(monkeypatch):
     org_url = "https://test.okta.com"
     token = "TOKEN"
     config = {'orgUrl': org_url, 'token': token, 'rateLimit': {'maxRetries': 2}}
@@ -67,7 +67,7 @@ def test_retry_count_header(monkeypatch):
 
     mock_http_request = MockHTTPRequest()
     monkeypatch.setattr(aiohttp.ClientSession, 'request', mock_http_request)
-    res, resp_body, error = asyncio.run(client.list_users())
+    res, resp_body, error = await client.list_users()
     # Check request was retried max times and header 'X-Okta-Retry-Count' was set properly
     assert mock_http_request.request_info['headers'].get('X-Okta-Retry-Count') == '2'
 

--- a/tests/unit/test_sign_on_modes.py
+++ b/tests/unit/test_sign_on_modes.py
@@ -1,5 +1,5 @@
-import asyncio
 import copy
+import pytest
 
 from okta.client import Client
 from okta.models import Application, SamlApplication, ApplicationSignOnMode
@@ -184,7 +184,8 @@ class MockRequestExecutor(RequestExecutor):
         self.response = MockResponseObj(response)
 
 
-def test_known_sign_on_mode():
+@pytest.mark.asyncio
+async def test_known_sign_on_mode():
     response = copy.deepcopy(SAML_APP_RESP_DICT)
 
     config = {
@@ -196,20 +197,19 @@ def test_known_sign_on_mode():
 
     # check list applications
     client._request_executor.set_response([response])
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.list_applications())
+    result, resp, err = await client.list_applications()
     assert type(result[0]) == SamlApplication
     assert result[0].as_dict() == EXPECTED_SAML_APP_AS_DICT
 
     # check get application
     client._request_executor.set_response(response)
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.get_application("test_id"))
+    result, resp, err = await client.get_application("test_id")
     assert type(result) == SamlApplication
     assert result.as_dict() == EXPECTED_SAML_APP_AS_DICT
 
 
-def test_unknown_sign_on_mode():
+@pytest.mark.asyncio
+async def test_unknown_sign_on_mode():
     response = copy.deepcopy(SAML_APP_RESP_DICT)
     response["signOnMode"] = "UNKNOWN_SIGN_ON_MODE"
     expected = copy.deepcopy(EXPECTED_SAML_APP_AS_DICT)
@@ -230,8 +230,7 @@ def test_unknown_sign_on_mode():
 
     # check list applications
     client._request_executor.set_response([response])
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.list_applications())
+    result, resp, err = await client.list_applications()
     # verify if result fallbacks to generic Application
     assert type(result[0]) != SamlApplication
     assert type(result[0]) == Application
@@ -239,15 +238,15 @@ def test_unknown_sign_on_mode():
 
     # check get application
     client._request_executor.set_response(response)
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.get_application("test_id"))
+    result, resp, err = await client.get_application("test_id")
     # verify if result fallbacks to generic Application
     assert type(result) != SamlApplication
     assert type(result) == Application
     assert result.as_dict() == expected
 
 
-def test_no_sign_on_mode():
+@pytest.mark.asyncio
+async def test_no_sign_on_mode():
     response = copy.deepcopy(SAML_APP_RESP_DICT)
     response["signOnMode"] = None
     expected = copy.deepcopy(EXPECTED_SAML_APP_AS_DICT)
@@ -268,16 +267,14 @@ def test_no_sign_on_mode():
 
     # check list applications
     client._request_executor.set_response([response])
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.list_applications())
+    result, resp, err = await client.list_applications()
     assert type(result[0]) != SamlApplication
     assert type(result[0]) == Application
     assert result[0].as_dict() == expected
 
     # check get application
     client._request_executor.set_response(response)
-    event_loop = asyncio.get_event_loop()
-    result, resp, err = event_loop.run_until_complete(client.get_application("test_id"))
+    result, resp, err = await client.get_application("test_id")
     assert type(result) != SamlApplication
     assert type(result) == Application
     assert result.as_dict() == expected


### PR DESCRIPTION
This PR should allow running all tests on any platform, depends on pytest-asyncio implementation