### PR TITLE
Manage custom group profile attributes. Related to GH #279

### DIFF
--- a/okta/models/group_profile.py
+++ b/okta/models/group_profile.py
@@ -20,6 +20,8 @@ limitations under the License.
 
 from okta.okta_object import OktaObject
 
+from okta.helpers import to_snake_case, to_lower_camel_case
+
 
 class GroupProfile(
     OktaObject
@@ -28,6 +30,11 @@ class GroupProfile(
     A class for GroupProfile objects.
     """
 
+    BASIC_ATTRIBUTES = (
+        "description",
+        "name",
+    )
+
     def __init__(self, config=None):
         super().__init__(config)
         if config:
@@ -35,6 +42,11 @@ class GroupProfile(
                 if "description" in config else None
             self.name = config["name"]\
                 if "name" in config else None
+            # set custom attributes not defined in model, do not change string case
+            for attr_name in config:
+                lower_camel_case = to_lower_camel_case(attr_name)
+                if lower_camel_case not in GroupProfile.BASIC_ATTRIBUTES:
+                    setattr(self, attr_name, config[attr_name])
         else:
             self.description = None
             self.name = None
@@ -45,5 +57,33 @@ class GroupProfile(
             "description": self.description,
             "name": self.name
         }
+        available_attrs = vars(self)
+        for attr in available_attrs:
+            # do not allow overriding of base attributes
+            if not attr in current_obj_format:
+                current_obj_format[attr] = getattr(self, attr)
         parent_req_format.update(current_obj_format)
         return parent_req_format
+
+    def __getattr__(self, attr_name):
+        """
+        Try different cases for backward compatibility.
+        """
+        available_attrs = vars(self)
+        snake_case = to_snake_case(attr_name)
+        if snake_case in available_attrs:
+            return available_attrs[snake_case]
+        lower_camel_case = to_lower_camel_case(attr_name)
+        if lower_camel_case in available_attrs:
+            return available_attrs[lower_camel_case]
+        raise AttributeError(f"'GroupProfile' object has no attribute '{attr_name}'")
+
+    def __setattr__(self, attr_name, attr_value):
+        """
+        Keep custom attributes unchanged and keep backward compatibility for basic attributes.
+        """
+        lower_camel_case = to_lower_camel_case(attr_name)
+        if lower_camel_case in GroupProfile.BASIC_ATTRIBUTES:
+            super(GroupProfile, self).__setattr__(lower_camel_case, attr_value)
+        else:
+            super(GroupProfile, self).__setattr__(attr_name, attr_value)

--- a/openapi/templates/model.py.hbs
+++ b/openapi/templates/model.py.hbs
@@ -50,7 +50,7 @@ from okta.models.{{snakeCase model.extends}}\
 {{else}}
 from okta.okta_object import OktaObject
 {{/if}}
-{{#if (eq model.modelName "UserProfile")}}
+{{#if (or (eq model.modelName "UserProfile") (eq model.modelName "GroupProfile"))}}
 
 from okta.helpers import to_snake_case, to_lower_camel_case
 {{/if}}
@@ -79,7 +79,7 @@ class {{pascalCase model.modelName}}(
     """
     A class for {{pascalCase model.modelName}} objects.
     """
-    {{#if (eq model.modelName "UserProfile")}}
+    {{#if (or (eq model.modelName "UserProfile") (eq model.modelName "GroupProfile"))}}
 
     BASIC_ATTRIBUTES = (
         {{#each model.properties as |prop|}}
@@ -151,11 +151,11 @@ class {{pascalCase model.modelName}}(
             {{/if}}
             {{/if}}
             {{/each}}
-            {{#if (eq model.modelName "UserProfile")}}
+            {{#if (or (eq model.modelName "UserProfile") (eq model.modelName "GroupProfile"))}}
             # set custom attributes not defined in model, do not change string case
             for attr_name in config:
                 lower_camel_case = to_lower_camel_case(attr_name)
-                if lower_camel_case not in UserProfile.BASIC_ATTRIBUTES:
+                if lower_camel_case not in {{model.modelName}}.BASIC_ATTRIBUTES:
                     setattr(self, attr_name, config[attr_name])
             {{/if}}
         else:
@@ -186,7 +186,7 @@ class {{pascalCase model.modelName}}(
             {{/each}}
         }
         {{/if}}
-        {{#if (eq model.modelName "UserProfile")}}
+        {{#if (or (eq model.modelName "UserProfile") (eq model.modelName "GroupProfile"))}}
         available_attrs = vars(self)
         for attr in available_attrs:
             # do not allow overriding of base attributes
@@ -195,7 +195,7 @@ class {{pascalCase model.modelName}}(
         {{/if}}
         parent_req_format.update(current_obj_format)
         return parent_req_format
-    {{#if (eq model.modelName "UserProfile")}}
+    {{#if (or (eq model.modelName "UserProfile") (eq model.modelName "GroupProfile"))}}
 
     def __getattr__(self, attr_name):
         """
@@ -208,16 +208,16 @@ class {{pascalCase model.modelName}}(
         lower_camel_case = to_lower_camel_case(attr_name)
         if lower_camel_case in available_attrs:
             return available_attrs[lower_camel_case]
-        raise AttributeError(f"'UserProfile' object has no attribute '{attr_name}'")
+        raise AttributeError(f"'{{model.modelName}}' object has no attribute '{attr_name}'")
 
     def __setattr__(self, attr_name, attr_value):
         """
         Keep custom attributes unchanged and keep backward compatibility for basic attributes.
         """
         lower_camel_case = to_lower_camel_case(attr_name)
-        if lower_camel_case in UserProfile.BASIC_ATTRIBUTES:
-            super(UserProfile, self).__setattr__(lower_camel_case, attr_value)
+        if lower_camel_case in {{model.modelName}}.BASIC_ATTRIBUTES:
+            super({{model.modelName}}, self).__setattr__(lower_camel_case, attr_value)
         else:
-            super(UserProfile, self).__setattr__(attr_name, attr_value)
+            super({{model.modelName}}, self).__setattr__(attr_name, attr_value)
     {{/if}}
 {{/if}}

--- a/tests/integration/cassettes/test_groups_it/TestGroupsResource.test_group_profile_custom_attributes.yaml
+++ b/tests/integration/cassettes/test_groups_it/TestGroupsResource.test_group_profile_custom_attributes.yaml
@@ -1,0 +1,306 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS myAPIToken
+      User-Agent:
+      - okta-sdk-python/2.4.0 python/3.8.2 Darwin/20.6.0
+    method: GET
+    uri: https://test.okta.com/api/v1/groups/test_group_id
+  response:
+    body:
+      string: '{"id":"test_group_id","created":"2021-06-04T07:57:00.000Z","lastUpdated":"2022-02-17T15:02:21.000Z","lastMembershipUpdated":"2021-06-07T11:12:33.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"Basic
+        Auth Web","description":null,"customGroupAttribute":"custom_group_attr_value"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.1a5ebe44c4244fb796c235d86b47e3bb.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.d9cfbd8a00a4feac1aa5612ba02e99c0.png","type":"image/png"}],"users":{"href":"https://test.okta.com/api/v1/groups/test_group_id/users"},"apps":{"href":"https://test.okta.com/api/v1/groups/test_group_id/apps"}}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Feb 2022 15:02:44 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      Server:
+      - nginx
+      Set-Cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=7661C40C405743467C80405135105528; Path=/; Secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-security-policy:
+      - 'default-src ''self'' test.okta.com *.oktacdn.com; connect-src ''self''
+        test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com
+        com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
+        *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
+      content-security-policy-report-only: 'default-src ''self'' test.okta.com *.oktacdn.com;
+        connect-src ''self'' test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline'' ''self''
+        test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com com-okta-authenticator:;
+        img-src ''self'' test.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      expect-ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      p3p:
+      - CP="HONK"
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - Yg5jlK35tJycDUsSLIChrwAADjE
+      x-rate-limit-limit:
+      - '100'
+      x-rate-limit-remaining:
+      - '96'
+      x-rate-limit-reset:
+      - '1645110199'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+    url: https://test.okta.com/api/v1/groups/test_group_id
+- request:
+    body: '{"profile": {"name": "Basic Auth Web", "customGroupAttribute": "new_custom_group_attr_value"}}'
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS myAPIToken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - okta-sdk-python/2.4.0 python/3.8.2 Darwin/20.6.0
+    method: PUT
+    uri: https://test.okta.com/api/v1/groups/test_group_id
+  response:
+    body:
+      string: '{"id":"test_group_id","created":"2021-06-04T07:57:00.000Z","lastUpdated":"2022-02-17T15:02:45.000Z","lastMembershipUpdated":"2021-06-07T11:12:33.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"Basic
+        Auth Web","description":null,"customGroupAttribute":"new_custom_group_attr_value"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.1a5ebe44c4244fb796c235d86b47e3bb.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.d9cfbd8a00a4feac1aa5612ba02e99c0.png","type":"image/png"}],"users":{"href":"https://test.okta.com/api/v1/groups/test_group_id/users"},"apps":{"href":"https://test.okta.com/api/v1/groups/test_group_id/apps"}}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Feb 2022 15:02:45 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      Server:
+      - nginx
+      Set-Cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=A1FDADD1D362E4804B4CD03A73973917; Path=/; Secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-security-policy:
+      - 'default-src ''self'' test.okta.com *.oktacdn.com; connect-src ''self''
+        test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com
+        com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
+        *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
+      content-security-policy-report-only: 'default-src ''self'' test.okta.com *.oktacdn.com;
+        connect-src ''self'' test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline'' ''self''
+        test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com com-okta-authenticator:;
+        img-src ''self'' test.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      expect-ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      p3p:
+      - CP="HONK"
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - Yg5jlTWIf8NfkT0Ypu1xYAAAAm4
+      x-rate-limit-limit:
+      - '100'
+      x-rate-limit-remaining:
+      - '95'
+      x-rate-limit-reset:
+      - '1645110199'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+    url: https://test.okta.com/api/v1/groups/test_group_id
+- request:
+    body: '{"profile": {"name": "Basic Auth Web", "customGroupAttribute": "custom_group_attr_value"}}'
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - SSWS myAPIToken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - okta-sdk-python/2.4.0 python/3.8.2 Darwin/20.6.0
+    method: PUT
+    uri: https://test.okta.com/api/v1/groups/test_group_id
+  response:
+    body:
+      string: '{"id":"test_group_id","created":"2021-06-04T07:57:00.000Z","lastUpdated":"2022-02-17T15:02:46.000Z","lastMembershipUpdated":"2021-06-07T11:12:33.000Z","objectClass":["okta:user_group"],"type":"OKTA_GROUP","profile":{"name":"Basic
+        Auth Web","description":null,"customGroupAttribute":"custom_group_attr_value"},"_links":{"logo":[{"name":"medium","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-medium.1a5ebe44c4244fb796c235d86b47e3bb.png","type":"image/png"},{"name":"large","href":"https://ok12static.oktacdn.com/assets/img/logos/groups/odyssey/okta-large.d9cfbd8a00a4feac1aa5612ba02e99c0.png","type":"image/png"}],"users":{"href":"https://test.okta.com/api/v1/groups/test_group_id/users"},"apps":{"href":"https://test.okta.com/api/v1/groups/test_group_id/apps"}}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Feb 2022 15:02:46 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      Server:
+      - nginx
+      Set-Cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - JSESSIONID=DD297C1550589B4678296E0F3BF42224; Path=/; Secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      content-security-policy:
+      - 'default-src ''self'' test.okta.com *.oktacdn.com; connect-src ''self''
+        test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com
+        com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
+        *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
+      content-security-policy-report-only: 'default-src ''self'' test.okta.com *.oktacdn.com;
+        connect-src ''self'' test.okta.com test-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        *.authenticatorlocalprod.com:8769 http://localhost:8769 http://127.0.0.1:8769
+        *.authenticatorlocalprod.com:65111 http://localhost:65111 http://127.0.0.1:65111
+        *.authenticatorlocalprod.com:65121 http://localhost:65121 http://127.0.0.1:65121
+        *.authenticatorlocalprod.com:65131 http://localhost:65131 http://127.0.0.1:65131
+        *.authenticatorlocalprod.com:65141 http://localhost:65141 http://127.0.0.1:65141
+        *.authenticatorlocalprod.com:65151 http://localhost:65151 http://127.0.0.1:65151
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' test.okta.com *.oktacdn.com; style-src ''unsafe-inline'' ''self''
+        test.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' test.okta.com test-admin.okta.com login.okta.com com-okta-authenticator:;
+        img-src ''self'' test.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      expect-ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      p3p:
+      - CP="HONK"
+      x-content-type-options:
+      - nosniff
+      x-okta-request-id:
+      - Yg5jluj8l3xrvee3VhZRYgAAAKM
+      x-rate-limit-limit:
+      - '100'
+      x-rate-limit-remaining:
+      - '94'
+      x-rate-limit-reset:
+      - '1645110199'
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+    url: https://test.okta.com/api/v1/groups/test_group_id
+version: 1


### PR DESCRIPTION
This PR allows to add custom attributes to GroupProfile object.
```py
group, okta_resp, err = await client.get_group(group_id)
# group.profile should contain custom attributes which come within okta_resp
```

Related to https://github.com/okta/okta-sdk-python/issues/279