### PR TITLE
Fixing openID Apps that return Dynamic Mode

### DIFF
--- a/okta/models/open_id_connect_application_issuer_mode.py
+++ b/okta/models/open_id_connect_application_issuer_mode.py
@@ -31,3 +31,4 @@ class OpenIdConnectApplicationIssuerMode(
 
     CUSTOM_URL = "CUSTOM_URL", "custom_url"
     ORG_URL = "ORG_URL", "org_url"
+    DYNAMIC = "DYNAMIC", "dynamic"


### PR DESCRIPTION
Certain OAuth apps can return DYNAMIC as a issuer mode, this wasn't supported previously by the IssuerModel as outlined in #286 and #287 and https://github.com/okta/okta-management-openapi-spec/issues/121 