### PR TITLE
Adds ability to specific a key id for the JWT token 

### DIFF
--- a/okta/jwt.py
+++ b/okta/jwt.py
@@ -92,7 +92,7 @@ class JWT():
         return (my_pem, my_jwk)
 
     @staticmethod
-    def create_token(org_url, client_id, private_key):
+    def create_token(org_url, client_id, private_key, kid=None):
         """
         Create a JSON Web Token using Oauth details from the Okta Client
         config.
@@ -123,5 +123,10 @@ class JWT():
             'jti': generated_JWT_ID
         }
 
-        token = jwt.encode(claims, my_jwk.to_dict(), JWT.HASH_ALGORITHM)
+        # Check if kid was supplied
+        if kid:
+            kid = {'kid': kid}
+
+        token = jwt.encode(claims, my_jwk.to_dict(), JWT.HASH_ALGORITHM, kid)
         return token
+

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -24,8 +24,9 @@ class OAuth:
         org_url = self._config["client"]["orgUrl"]
         client_id = self._config["client"]["clientId"]
         private_key = self._config["client"]["privateKey"]
+        kid = self._config["client"].get("kid")
 
-        return JWT.create_token(org_url, client_id, private_key)
+        return JWT.create_token(org_url, client_id, private_key, kid)
 
     async def get_access_token(self):
         """


### PR DESCRIPTION
[Addresses](https://github.com/okta/okta-sdk-python/issues/289)

When a service application in Okta has more than a single JWK registered, then the JWT assertion used to retrieve access token needs to specify the key id (kid)  to be used in the JWT Header, otherwise the request will fail.