### PR TITLE
Adding MFA_ENROLL policy support

### DIFF
--- a/okta/constants.py
+++ b/okta/constants.py
@@ -79,6 +79,7 @@ def find_factor_model(factor_type):
 OKTA_POLICY_TYPE_TO_MODEL = {
     PT.ACCESS_POLICY: models.AccessPolicy,
     PT.IDP_DISCOVERY: models.IdentityProviderPolicy,
+    PT.MFA_ENROLL: models.MFAEnrollPolicy,
     PT.OAUTH_AUTHORIZATION_POLICY: models.OAuthAuthorizationPolicy,
     PT.OKTA_SIGN_ON: models.OktaSignOnPolicy,
     PT.PASSWORD: models.PasswordPolicy,

--- a/okta/models/__init__.py
+++ b/okta/models/__init__.py
@@ -486,6 +486,8 @@ from okta.models import o_auth_grant_type as o_auth_grant_type
 OAuthGrantType = o_auth_grant_type.OAuthGrantType
 from okta.models import o_auth_response_type as o_auth_response_type
 OAuthResponseType = o_auth_response_type.OAuthResponseType
+from okta.models import mfa_enrollment_policy as mfa_enrollment_policy
+MFAEnrollPolicy = mfa_enrollment_policy.MFAEnrollPolicy
 from okta.models import okta_sign_on_policy as okta_sign_on_policy
 OktaSignOnPolicy = okta_sign_on_policy.OktaSignOnPolicy
 from okta.models import okta_sign_on_policy_conditions as okta_sign_on_policy_conditions

--- a/okta/models/mfa_enrollment_policy.py
+++ b/okta/models/mfa_enrollment_policy.py
@@ -18,21 +18,30 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from okta.models.policy\
+    import Policy
+from okta.models.policy_type import PolicyType
 
 
-class PolicyType(
-    str,
-    MultiValueEnum
+class MFAEnrollPolicy(
+    Policy
 ):
     """
-    An enumeration class for PolicyType.
+    A class for MFAEnrollPolicy objects.
     """
 
-    OAUTH_AUTHORIZATION_POLICY = "OAUTH_AUTHORIZATION_POLICY", "oauth_authorization_policy"
-    OKTA_SIGN_ON = "OKTA_SIGN_ON", "okta_sign_on"
-    PASSWORD = "PASSWORD", "password"
-    IDP_DISCOVERY = "IDP_DISCOVERY", "idp_discovery"
-    PROFILE_ENROLLMENT = "PROFILE_ENROLLMENT", "profile_enrollment"
-    ACCESS_POLICY = "ACCESS_POLICY", "access_policy"
-    MFA_ENROLL = "MFA_ENROLL", "mfa_enroll"
+    def __init__(self, config=None):
+        super().__init__(config)
+        if config:
+            self.type = PolicyType("MFA_ENROLL")
+            self.conditions = None
+        else:
+            self.conditions = None
+
+    def request_format(self):
+        parent_req_format = super().request_format()
+        current_obj_format = {
+            "conditions": self.conditions
+        }
+        parent_req_format.update(current_obj_format)
+        return parent_req_format


### PR DESCRIPTION
MFA_ENROLL is a valid policy type (https://developer.okta.com/docs/reference/api/policy/#policy-object) but was not supported by the SDK. This adds basic support for this policy type.