### PR TITLE
Support customized HTTP Request Headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+version: 2.1
+
+orbs:
+  python: circleci/python@2.1.1
+
+jobs:
+  build_and_test:
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Build
+          command: python setup.py build
+      - run:
+          name: Run Tests
+          command: pytest
+workflows:
+  main:
+    jobs:
+      - build_and_test

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ __pycache__/
 # JS files
 */node_modules/
 *package-lock.json
+
+# Build files
+build/

--- a/okta/request_executor.py
+++ b/okta/request_executor.py
@@ -118,8 +118,8 @@ class RequestExecutor:
 
         # Build request
         # Get predetermined headers and build URL
-        headers.update(self._custom_headers)
-        headers.update(self._default_headers)
+        headers = {**self._custom_headers, **headers}
+        headers = {**self._default_headers, **headers}
         if self._config["client"]["orgUrl"] not in url:
             url = self._config["client"]["orgUrl"] + url
 

--- a/tests/unit/test_request_executor.py
+++ b/tests/unit/test_request_executor.py
@@ -9,6 +9,7 @@ from multidict import MultiDict
 from okta.client import Client as OktaClient
 from okta.request_executor import RequestExecutor
 
+
 def test_retry_count_header(monkeypatch):
     org_url = "https://test.okta.com"
     token = "TOKEN"
@@ -29,11 +30,13 @@ def test_retry_count_header(monkeypatch):
 
         def __call__(self, **params):
             self.request_info = params
-            self.headers = MultiDict({'Date': datetime.datetime.now(tz=datetime.timezone.utc).strftime('%a, %d %b %Y %H:%M:%S %Z'),
-                                      'Content-Type': 'application/json',
-                                      'X-Rate-Limit-Limit': 600,
-                                      'X-Rate-Limit-Remaining': 599,
-                                      'X-Rate-Limit-Reset': str(time.time())})
+            self.headers = MultiDict(
+                {'Date': datetime.datetime.now(tz=datetime.timezone.utc).strftime('%a, %d %b %Y %H:%M:%S %Z'),
+                 'Content-Type': 'application/json',
+                 'X-Rate-Limit-Limit': 600,
+                 'X-Rate-Limit-Remaining': 599,
+                 'X-Rate-Limit-Reset': str(time.time())}
+            )
             self.url = params['url']
             self.content_type = 'application/json'
             self.links = ''
@@ -95,18 +98,18 @@ def test_clear_empty_params():
     body = {'int_value': 0,
             'str_value': '0',
             'empty_str_value': '',
-            'list_value': [1,2,3],
+            'list_value': [1, 2, 3],
             'empty_list_value': [],
             'dict_value': {'int_value': 0},
             'empty_dict_value': {},
-            'nested_empty_dict_value': {'list_value': [1,2,3], 'empty_list_value': []},
+            'nested_empty_dict_value': {'list_value': [1, 2, 3], 'empty_list_value': []},
             'nested_empty_list_value': {'empty_list_value': []}}
 
     cleared_body = {'int_value': 0,
                     'str_value': '0',
-                    'list_value': [1,2,3],
+                    'list_value': [1, 2, 3],
                     'dict_value': {'int_value': 0},
-                    'nested_empty_dict_value': {'list_value': [1,2,3]}}
+                    'nested_empty_dict_value': {'list_value': [1, 2, 3]}}
 
     assert req_exec.clear_empty_params(body) == cleared_body
 
@@ -135,5 +138,6 @@ async def test_overwrite_default_request_executor_headers(accept_header):
         header_overwrite,
         {}
     )
+    assert request is not None
     assert request["headers"]["Accept"] ==\
         accept_header if accept_header else "application/json"


### PR DESCRIPTION
For [OKTA-525379](https://oktainc.atlassian.net/browse/OKTA-525379):
- Problem has been raised in a number of GH issues that custom headers do not overwrite the default ones, especially the `Accept` header which defaults to `application/json`
- Fix problem where sometimes headers weren't being overwritten correctly
- Add test to verify