### PR TITLE
Specify kid when provided for JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ config = {
     'authorizationMode': 'PrivateKey',
     'clientId': '{yourClientId}',
     'scopes': ['okta.users.manage'],
-    'privateKey': 'YOUR_PRIVATE_JWK' # this parameter should be type of str
+    'privateKey': 'YOUR_PRIVATE_JWK', # this parameter should be type of str
+    'kid': 'YOUR_PRIVATE_KEY_ID' # if a key ID needs to be provided, it can be provided here or part of the privateKey under "kid"
 }
 okta_client = OktaClient(config)
 

--- a/okta/jwt.py
+++ b/okta/jwt.py
@@ -1,3 +1,4 @@
+import json
 from Crypto.PublicKey import RSA
 from ast import literal_eval
 import jose.jwk as jwk
@@ -66,7 +67,7 @@ class JWT():
             my_jwk = jwk.construct(private_key, JWT.HASH_ALGORITHM)
         else:  # it's a PEM
             # check for filepath or explicit private key
-            if os.path.exists(private_key):
+            if isinstance(private_key, (str, bytes, os.PathLike)) and os.path.exists(private_key):
                 # open file if exists and import key
                 pem_file = open(private_key, 'r')
                 my_pem = RSA.import_key(pem_file.read())
@@ -92,7 +93,7 @@ class JWT():
         return (my_pem, my_jwk)
 
     @staticmethod
-    def create_token(org_url, client_id, private_key):
+    def create_token(org_url, client_id, private_key, kid=None):
         """
         Create a JSON Web Token using Oauth details from the Okta Client
         config.
@@ -101,6 +102,7 @@ class JWT():
             org_url (str): Okta Organization URL
             client_id (str): Client ID
             private_key (str or dict): Private Key representation
+            kid (str): Key ID
 
         Returns:
             str: Generated JWT
@@ -123,5 +125,22 @@ class JWT():
             'jti': generated_JWT_ID
         }
 
-        token = jwt.encode(claims, my_jwk.to_dict(), JWT.HASH_ALGORITHM)
+        # Add additional headers
+        headers = {}
+
+        # # Check if kid was supplied
+        if kid:
+            headers["kid"] = kid
+        elif isinstance(private_key, dict) and "kid" in private_key:
+            headers["kid"] = private_key["kid"]
+        elif isinstance(private_key, str):
+            try:
+                private_key_dict = json.loads(private_key)
+                if "kid" in private_key_dict:
+                    headers["kid"] = private_key_dict["kid"]
+            except json.JSONDecodeError:
+                if "kid" in headers:
+                    del headers["kid"]
+
+        token = jwt.encode(claims, my_jwk.to_dict(), JWT.HASH_ALGORITHM, headers=headers)
         return token

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -24,8 +24,10 @@ class OAuth:
         org_url = self._config["client"]["orgUrl"]
         client_id = self._config["client"]["clientId"]
         private_key = self._config["client"]["privateKey"]
+        # check if kid is provided in config - set if so
+        kid = self._config["client"]["kid"] if "kid" in self._config["client"] else None
 
-        return JWT.create_token(org_url, client_id, private_key)
+        return JWT.create_token(org_url, client_id, private_key, kid)
 
     async def get_access_token(self):
         """

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -243,6 +243,7 @@ def mock_cache_return_none(*args, **kwargs):
 def mock_cache_return_value(*args, **kwargs):
     return CACHE_VALUE
 
+
 def mock_next_link(self_url: URL):
     return self_url.update_query({'after': 'mock_after_id'})
 
@@ -345,3 +346,45 @@ SAMPLE_JWK = {'alg': 'RS256',
                  kHsfHpFi4d4qS3J5kMvVUyIY3DwOsQenLo8C-
                  orgmo4UstEjNQ1OQt04mV1fp1aE2b9JVjv72c
                  PEE1SMqaEp7W0dBcm49L0mY7sNyEFS0U'''}
+
+SAMPLE_JWK_WITH_KID = {
+    "p": '''7nyZPzjUrUKoM-1DlzkJdFfD2R6hYTY9BMkoXYIu4S
+    ChhFrEgInH9hwQeMYT0wZTx2lcwVM3ZMpMaotaVAIVBHAK9i_C
+    Is2hANqtoXhE7IDKnaecV10htbV2dD1PpgDyK7_tv_vdAlsN1K
+    OSmg4Yb4uCsaambTUbV3rAUsSyu9E''',
+    "kty": "RSA",
+    "q": '''zijXO-JzhzBeBtg4zIkMdKGj0ewvWoLTDni7sNXhkt
+    XDKQT_5FvOptzFDn39sVJvBE69bF6pf_dH1rpKJxrLCkk0p734
+    0bdfq4AoHSnTIYToX31PlOWwgfJVebB7q_oGRe9UcA5Svb_WDh
+    4IkN9IyRrnFBWpPClpcNz_KOHMRck''',
+    "d": '''rP42vnls34ptQZHDXduD521BLqZX6Mgu2YrWXZN3-N
+    aMziVn_t14Q0ifpJR7rfD5Cw1yTpRmyc01VN2wBWfpwqJrzQZ3
+    2a1pFB_KgLGRBctjQx6DIDrqGVkRHUZHghnVVdrjEjolTaqBRP
+    4R20_csZEikNrz36zntUUtiG9Mnz27Z26UyD-odXSVZmtseRMX
+    aiGPKwg837w1ubT0lMZkYCZIdU2okxaLPw4L-peDaX4JLS7ZPE
+    7FkKK6rBXK9FquESMr6wTatz7TVyU0tToTL6JIS6pze29jaQ4A
+    w9iPxQZqR6-LeidTOLmwkYKx8WSoM5ymCMmW4ERDxsWYEP48AQ''',
+    "e": "AQAB",
+    "use": "sig",
+    "qi": '''vz8N-1OZb_Mc9qtBGaY3c2sLkGf9IaagEEzxC2sr00
+    4fGIqqXivpaZrs21y8y0d1sQG08K1zW6_S3_rpOZ7iJHnt3qD_U
+    J57JDX76LaQY0YyF9-R_qlRgvcnK_mU1OXSnGYhwZxqb78D3TAa
+    nKou31h-iEyxy_Mf-OpoPDAoLBE''',
+    "dp": '''CI4htTnlrz136Tz2ssMSCsFnPi-yHFmkwLoyn4AfDG
+    ZuROA4sl--8544HQ0GAwj0EnA-KpVApHX5Xc0X9XGJrXoTepdmA
+    Hed8fjmR6eX2WAZZKRxoFSv8-PJlwvoAo2AIn-lGMEBQadgjKM9
+    jBc7Wy0HCDZxO_Ouwmmd4po5yzE''',
+    "alg": "RS256",
+    "dq": '''c1I9M-50mYbg0gtZmnB_Wy6gKOlpg8PytAGtXDoIOM
+    8CoIt_aQpCCu0r_fNUWkC2gT5aj6hUQJTexqrmmAFQ2qwgnESUT
+    xu4lILX7Zhb1kA2jFPYlH33wnkAf1XNmGH_6Fb8cMJSXnpVDwiV
+    2hRM7tHxuTZ0uIahyNSWlxPX5KE''',
+    "n": '''wA5PSz_9DibXonaaLJxD31L9CIhNgB8v_OttNyt-lDP
+    JWBhhk0uySnSDDua1u5Ifaid4H_JargmkEooHtxwQJLBNpAD-F6
+    74D9vGRdrRBdj5k0eZTZmPwHTAtnK3SPcduwf7wUNNbx757TGJY
+    _VHpbgiSQ2EH12rJnYJtCWy1huYPa5bW3vDBnT7b1i83pESjyT1
+    g3DFnDzReGe-UIx8UTJOOgNRb_C9DXtotD8Gjdj56NiaDg7V1ek
+    YBFFIZp9Urm39Hlaus0FRT7xL8tHEuSfD7S6HpFsTk5yDDDDqyv
+    KLElmMvzocvFaWKvup_a3vPaBi6y4K5kBiq60o-IDMGQ''',
+    "kid": "5ashWt3LP1zkYwMGbfMsVizRfx52QTyky4GTHd9MykE"
+}

--- a/tests/unit/test_jwt.py
+++ b/tests/unit/test_jwt.py
@@ -1,0 +1,26 @@
+from okta.jwt import JWT
+import tests.mocks as mocks
+
+"""
+Testing JWT functions with different inputs
+"""
+
+
+def test_private_key_with_kid_in_private_key(mocker):
+    mocked_encode = mocker.patch('jose.jwt.encode')
+    JWT.create_token("test.com", "test-client-id", mocks.SAMPLE_JWK_WITH_KID)
+    expected_kid = mocks.SAMPLE_JWK_WITH_KID["kid"]
+    _, kwargs = mocked_encode.call_args
+    mocked_encode.assert_called_once()
+    assert "kid" in kwargs["headers"]
+    assert kwargs["headers"]["kid"] == expected_kid
+
+
+def test_private_key_with_kid_in_config(mocker):
+    mocked_encode = mocker.patch('jose.jwt.encode')
+    expected_kid = "test-kid"
+    JWT.create_token("test.com", "test-client-id", mocks.SAMPLE_JWK, kid=expected_kid)
+    _, kwargs = mocked_encode.call_args
+    mocked_encode.assert_called_once()
+    assert "kid" in kwargs["headers"]
+    assert kwargs["headers"]["kid"] == expected_kid

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -9,7 +9,7 @@ Testing Private Key Inputs
 
 
 @ pytest.mark.parametrize("jwk_input",
-                          [mocks.SAMPLE_JWK, str(mocks.SAMPLE_JWK)])
+                          [mocks.SAMPLE_JWK, str(mocks.SAMPLE_JWK), mocks.SAMPLE_JWK_WITH_KID])
 def test_private_key_PEM_JWK_dict(jwk_input):
     generated_pem, generated_jwk = JWT.get_PEM_JWK(jwk_input)
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -8,7 +8,7 @@ Testing Private Key Inputs
 """
 
 
-@ pytest.mark.parametrize("jwk_input",
+@pytest.mark.parametrize("jwk_input",
                           [mocks.SAMPLE_JWK, str(mocks.SAMPLE_JWK), mocks.SAMPLE_JWK_WITH_KID])
 def test_private_key_PEM_JWK_dict(jwk_input):
     generated_pem, generated_jwk = JWT.get_PEM_JWK(jwk_input)


### PR DESCRIPTION
Allow for JWT to be encoded with kid in headers when provided by user

Addressing https://github.com/okta/okta-sdk-python/issues/289