### PR TITLE
Supporting the previewSAMLAppMetadata operation

### DIFF
--- a/okta/api_response.py
+++ b/okta/api_response.py
@@ -95,7 +95,7 @@ class OktaAPIResponse():
         Args:
             response_body ([type]): [description]
         """
-        self._body = xmltodict.parse(response_body, xml_attribs=False)
+        self._body = xmltodict.parse(response_body, xml_attribs=True)
 
     def extract_pagination(self, links):
         """

--- a/openapi/templates/partials/models/defaultMethod.py.hbs
+++ b/openapi/templates/partials/models/defaultMethod.py.hbs
@@ -50,9 +50,16 @@
         form = {}
         {{/if}}
 
+        {{#if (eq operation.operationId "previewSAMLAppMetadata")}}
+        headers['Accept'] = "application/xml"
+        request, error = await self._request_executor.create_request(
+            http_method, api_url, None, headers, None, keep_empty_params=keep_empty_params
+        )
+        {{else}}
         request, error = await self._request_executor.create_request(
             http_method, api_url, body, headers, form, keep_empty_params=keep_empty_params
         )
+        {{/if}}
 
         if error:
         {{#if operation.responseModel}}
@@ -144,9 +151,13 @@
                 response.get_body()
             )
             {{else}}
+            {{#if (eq operation.operationId "previewSAMLAppMetadata")}}
+            result = (response.get_body())
+            {{else}}
             result = {{pascalCase operation.responseModel}}(
                 self.form_response_body(response.get_body())
             )
+            {{/if}}
             {{/if}}
             {{/if}}
             {{/if}}


### PR DESCRIPTION
This PR can be merged after https://github.com/okta/okta-management-openapi-spec/pull/166 is resolved

Snippet used to test
```py
resp, err = await okta_client.preview_saml_app_metadata('{{appId}}')
    print(resp)
    print(resp.get_body())
```

Generates method:
```py
async def preview_saml_app_metadata(
            self, appId, query_params={},
            keep_empty_params=False
    ):
        """
        Previews SAML metadata based on a specific key credenti
        al for an application
        Args:
            app_id {str}
            query_params {dict}: Map of query parameters for request
            [query_params.kid] {str}
        """
        http_method = "get".upper()
        api_url = format_url(f"""
            {self._base_url}
            /api/v1/apps/{appId}/sso/saml/metadata
            """)
        if query_params:
            encoded_query_params = urlencode(query_params)
            api_url += f"/?{encoded_query_params}"

        body = {}
        headers = {}
        form = {}

        headers['Accept'] = "application/xml"
        request, error = await self._request_executor.create_request(
            http_method, api_url, None, headers, None, keep_empty_params=keep_empty_params
        )

        if error:
            return (None, error)

        response, error = await self._request_executor\
            .execute(request)

        if error:
            return (response, error)

        return (response, None)
```