### PR TITLE
Correctly set logger level in config

### DIFF
--- a/okta/logger.py
+++ b/okta/logger.py
@@ -13,7 +13,7 @@ def setup_logging(log_level=logging.INFO):
 
     logger = logging.getLogger('okta-sdk-python')
     logger.addHandler(stream_handler)
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(log_level)
 
     # disable logger by default
     logger.disabled = True

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,37 @@
+from okta.client import Client as OktaClient
+import logging
+import pytest
+
+
+@pytest.mark.parametrize('log_level', [logging.INFO, logging.ERROR, logging.WARNING, logging.DEBUG])
+def test_client_log_level_set_correctly(log_level: int):
+    org_url = "https://test.okta.com"
+    token = "TOKEN"
+    config = {
+        'orgUrl': org_url,
+        'token': token,
+        'logging': {
+            'enabled': True,
+            'logLevel': log_level
+        }
+    }
+
+    # Ensure no error is raised and logger is set to correct level
+    _ = OktaClient(user_config=config)
+    assert logging.getLogger('okta-sdk-python').getEffectiveLevel() == log_level
+
+
+def test_client_log_level_set_correctly_default():
+    org_url = "https://test.okta.com"
+    token = "TOKEN"
+    config = {
+        'orgUrl': org_url,
+        'token': token,
+        'logging': {
+            'enabled': True
+        }
+    }
+
+    # Ensure no error is raised and logger is set to correct level (INFO)
+    _ = OktaClient(user_config=config)
+    assert logging.getLogger('okta-sdk-python').getEffectiveLevel() == logging.INFO


### PR DESCRIPTION
Correctly set logger level
- to either given input log level
- or default to INFO if not provided

Resolving https://github.com/okta/okta-sdk-python/issues/292