### PR TITLE
Removing expect-ct header from repo

### DIFF
--- a/tests/integration/cassettes/test_applications_it/TestApplicationsResource.test_get_default_provisioning_connection_for_application.yaml
+++ b/tests/integration/cassettes/test_applications_it/TestApplicationsResource.test_get_default_provisioning_connection_for_application.yaml
@@ -66,8 +66,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -150,8 +148,7 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+    
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -235,8 +232,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -313,8 +308,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_auth_server_it/TestAuthorizationServerResource.test_list_authorization_server_policy_rules.yaml
+++ b/tests/integration/cassettes/test_auth_server_it/TestAuthorizationServerResource.test_list_authorization_server_policy_rules.yaml
@@ -60,8 +60,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -142,8 +140,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -225,8 +221,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -309,8 +303,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -384,8 +376,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -459,8 +449,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -534,8 +522,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -609,8 +595,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_activate_and_deactivate_authenticator.yaml
+++ b/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_activate_and_deactivate_authenticator.yaml
@@ -65,8 +65,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -148,8 +146,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -231,8 +227,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_get_authenticator.yaml
+++ b/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_get_authenticator.yaml
@@ -65,8 +65,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -148,8 +146,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_list_authenticators.yaml
+++ b/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_list_authenticators.yaml
@@ -65,8 +65,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_update_authenticator.yaml
+++ b/tests/integration/cassettes/test_authenticators_it/TestAuthenticatorsResource.test_update_authenticator.yaml
@@ -63,8 +63,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -153,8 +151,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -244,8 +240,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_create_delete_email_template_customizations.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_create_delete_email_template_customizations.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -235,8 +231,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -323,8 +317,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -411,8 +403,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -492,8 +482,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -573,8 +561,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_background_image.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_background_image.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -214,8 +210,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_favicon.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_favicon.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -214,8 +210,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_logo.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_delete_brand_theme_logo.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -214,8 +210,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_brand.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_brand.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_brand_theme.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_brand_theme.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -222,8 +218,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_email_template.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_email_template.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -243,8 +239,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_email_template_customization_preview.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_email_template_customization_preview.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -235,8 +231,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -323,8 +317,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -415,8 +407,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -548,8 +538,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -678,8 +666,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -759,8 +745,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_update_email_template_customization.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_get_update_email_template_customization.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -235,8 +231,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -323,8 +317,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -415,8 +407,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -505,8 +495,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -586,8 +574,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_brand_themes.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_brand_themes.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_brands.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_brands.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_email_template_customizations.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_email_template_customizations.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -235,8 +231,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -323,8 +317,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -416,8 +408,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -497,8 +487,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_email_templates.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_list_email_templates.yaml
@@ -64,8 +64,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com
         fonts.gstatic.com; frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
         report-to csp'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_update_brand.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_update_brand.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -228,8 +224,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -314,8 +308,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_update_brand_theme.yaml
+++ b/tests/integration/cassettes/test_brands_it/TestBrandsResource.test_update_brand_theme.yaml
@@ -60,8 +60,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -223,8 +219,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -310,8 +304,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -396,8 +388,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' dev-44577309.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' dev-44577309.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_domains_it/TestDomainResource.test_create_and_delete_domain.yaml
+++ b/tests/integration/cassettes/test_domains_it/TestDomainResource.test_create_and_delete_domain.yaml
@@ -58,8 +58,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -133,8 +131,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_domains_it/TestDomainResource.test_get_domain.yaml
+++ b/tests/integration/cassettes/test_domains_it/TestDomainResource.test_get_domain.yaml
@@ -58,8 +58,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -141,8 +139,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -216,8 +212,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_domains_it/TestDomainResource.test_list_domains.yaml
+++ b/tests/integration/cassettes/test_domains_it/TestDomainResource.test_list_domains.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_add_and_remove_custom_attribute.yaml
+++ b/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_add_and_remove_custom_attribute.yaml
@@ -68,8 +68,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -154,8 +152,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_get_group_schema.yaml
+++ b/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_get_group_schema.yaml
@@ -64,8 +64,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_update_custom_attribute.yaml
+++ b/tests/integration/cassettes/test_group_schema_it/TestGroupSchemaResource.test_update_custom_attribute.yaml
@@ -68,8 +68,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -173,8 +171,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -260,8 +256,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_groups_it/TestGroupsResource.test_group_profile_custom_attributes.yaml
+++ b/tests/integration/cassettes/test_groups_it/TestGroupsResource.test_group_profile_custom_attributes.yaml
@@ -79,8 +79,6 @@ interactions:
         app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -181,8 +179,6 @@ interactions:
         app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -283,8 +279,6 @@ interactions:
         app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_create_and_delete_network_zone.yaml
+++ b/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_create_and_delete_network_zone.yaml
@@ -64,8 +64,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -147,8 +145,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -222,8 +218,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_list_network_zones.yaml
+++ b/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_list_network_zones.yaml
@@ -64,8 +64,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_update_network_zone.yaml
+++ b/tests/integration/cassettes/test_network_zone_it/TestNetworkZoneResource.test_update_network_zone.yaml
@@ -65,8 +65,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -156,8 +154,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -239,8 +235,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -314,8 +308,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_extend_okta_support.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_extend_okta_support.yaml
@@ -63,8 +63,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:
@@ -148,8 +146,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -231,8 +227,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_okta_communication_settings.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_okta_communication_settings.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_okta_support_settings.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_okta_support_settings.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_contact_types.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_contact_types.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_contact_user.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_contact_user.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_preferences.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_preferences.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_settings.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_get_org_settings.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_grant_revoke_okta_support.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_grant_revoke_okta_support.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -145,8 +143,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_hide_okta_ui_footer.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_hide_okta_ui_footer.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_opt_in_users_to_okta_communication_emails.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_opt_in_users_to_okta_communication_emails.yaml
@@ -63,8 +63,6 @@ interactions:
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com;
         report-uri https://okta.report-uri.com/r/d/csp/enforce; report-to csp-enforce'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       report-to:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_opt_out_users_from_okta_communication_emails.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_opt_out_users_from_okta_communication_emails.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_partial_setting_update.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_partial_setting_update.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -145,8 +143,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -228,8 +224,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_setting_update.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_setting_update.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -153,8 +151,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -245,8 +241,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_show_okta_ui_footer.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_show_okta_ui_footer.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_org_it/TestOrgResource.test_update_org_contact_user.yaml
+++ b/tests/integration/cassettes/test_org_it/TestOrgResource.test_update_org_contact_user.yaml
@@ -62,8 +62,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -145,8 +143,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -228,8 +224,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_get_role_subscription_by_notification_type.yaml
+++ b/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_get_role_subscription_by_notification_type.yaml
@@ -61,8 +61,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_list_role_subsription.yaml
+++ b/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_list_role_subsription.yaml
@@ -61,8 +61,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_subscribe_unsubscribe_role_by_notification_type.yaml
+++ b/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_subscribe_unsubscribe_role_by_notification_type.yaml
@@ -55,8 +55,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -137,8 +135,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -213,8 +209,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -295,8 +289,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -371,8 +363,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:

--- a/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_subscribe_unsubscribe_user.yaml
+++ b/tests/integration/cassettes/test_subscription_it/TestSubscriptionResource.test_subscribe_unsubscribe_user.yaml
@@ -64,8 +64,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -140,8 +138,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -222,8 +218,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -298,8 +292,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-frame-options:
@@ -380,8 +372,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_threat_insight_it/TestThreatInsightConfiguration.test_get_threat_insight_configuration.yaml
+++ b/tests/integration/cassettes/test_threat_insight_it/TestThreatInsightConfiguration.test_get_threat_insight_configuration.yaml
@@ -63,8 +63,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_threat_insight_it/TestThreatInsightConfiguration.test_update_threat_insight_configuration.yaml
+++ b/tests/integration/cassettes/test_threat_insight_it/TestThreatInsightConfiguration.test_update_threat_insight_configuration.yaml
@@ -63,8 +63,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -149,8 +147,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -235,8 +231,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test-org.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test-org.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_user_schema_it/TestUserSchemaResource.test_get_user_schema.yaml
+++ b/tests/integration/cassettes/test_user_schema_it/TestUserSchemaResource.test_get_user_schema.yaml
@@ -85,8 +85,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_user_schema_it/TestUserSchemaResource.test_update_user_profile.yaml
+++ b/tests/integration/cassettes/test_user_schema_it/TestUserSchemaResource.test_update_user_profile.yaml
@@ -85,8 +85,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -269,8 +267,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -456,8 +452,6 @@ interactions:
         data: blob: *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net
         *.zscalerthree.net; font-src data: ''self'' *.oktacdn.com fonts.gstatic.com
         *.zscloud.net *.zscalerbeta.net *.zscaler.net *.zscalertwo.net *.zscalerthree.net'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:

--- a/tests/integration/cassettes/test_users_it/TestUsersResource.test_list_user_subscriptions.yaml
+++ b/tests/integration/cassettes/test_users_it/TestUsersResource.test_list_user_subscriptions.yaml
@@ -64,8 +64,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:
@@ -146,8 +144,6 @@ interactions:
         com-okta-authenticator:; img-src ''self'' test.okta.com *.oktacdn.com
         *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
         data: blob:; font-src ''self'' test.okta.com data: *.oktacdn.com fonts.gstatic.com'
-      expect-ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       p3p:
       - CP="HONK"
       x-content-type-options:


### PR DESCRIPTION
Removing expect-ct header from repo
- in http cassete yaml files used for integration tests
- Should make [this search](https://github.com/search?q=org%3Aokta+oktaexpectct.report-uri.com%2Fr%2Ft%2Fct%2FreportOnly+NOT+repo%3Aokta%2Forion+NOT+repo%3Aokta%2Fokta-developer-docs&type=code&p=1) return 0 results