### PR TITLE
Properly clear access token

### DIFF
--- a/okta/api_response.py
+++ b/okta/api_response.py
@@ -176,5 +176,6 @@ class OktaAPIResponse():
                 next_response = OktaAPIResponse(
                     self._request_executor, req, res_details, resp_body)
                 self._next = next_response._next
+                self._resp_headers = res_details.headers
                 # yield next page
                 yield (next_response.get_body(), None)

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -90,6 +90,5 @@ class OAuth:
         Clear currently used OAuth access token, probably expired
         """
         self._access_token = None
-        self._request_executor._oauth.clear_access_token()
         self._request_executor._cache.delete("OKTA_ACCESS_TOKEN")
         self._request_executor._default_headers.pop("Authorization", None)

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -90,3 +90,6 @@ class OAuth:
         Clear currently used OAuth access token, probably expired
         """
         self._access_token = None
+        self._request_executor._oauth.clear_access_token()
+        self._request_executor._cache.delete("OKTA_ACCESS_TOKEN")
+        self._request_executor._default_headers.pop("Authorization", None)


### PR DESCRIPTION
Remove the access token from request headers and cache when calling `clear_access_token`. Also update the request headers in `get_next` to prevent usage of old token. 

See [issue 363](https://github.com/okta/okta-sdk-python/issues/363) and [issue 359](https://github.com/okta/okta-sdk-python/issues/359)