### PR TITLE
Add ReprEnum to auto generated models

### DIFF
--- a/okta/models/allowed_for_enum.py
+++ b/okta/models/allowed_for_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AllowedForEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AllowedForEnum.

--- a/okta/models/application_credentials_scheme.py
+++ b/okta/models/application_credentials_scheme.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ApplicationCredentialsScheme(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ApplicationCredentialsScheme.

--- a/okta/models/application_credentials_signing_use.py
+++ b/okta/models/application_credentials_signing_use.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ApplicationCredentialsSigningUse(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ApplicationCredentialsSigningUse.

--- a/okta/models/authentication_provider_type.py
+++ b/okta/models/authentication_provider_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AuthenticationProviderType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AuthenticationProviderType.

--- a/okta/models/authenticator_status.py
+++ b/okta/models/authenticator_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AuthenticatorStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AuthenticatorStatus.

--- a/okta/models/authenticator_type.py
+++ b/okta/models/authenticator_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AuthenticatorType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AuthenticatorType.

--- a/okta/models/authorization_server_credentials_rotation_mode.py
+++ b/okta/models/authorization_server_credentials_rotation_mode.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AuthorizationServerCredentialsRotationMode(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AuthorizationServerCredentialsRotationMode.

--- a/okta/models/authorization_server_credentials_use.py
+++ b/okta/models/authorization_server_credentials_use.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class AuthorizationServerCredentialsUse(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for AuthorizationServerCredentialsUse.

--- a/okta/models/catalog_application_status.py
+++ b/okta/models/catalog_application_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class CatalogApplicationStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for CatalogApplicationStatus.

--- a/okta/models/change_enum.py
+++ b/okta/models/change_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ChangeEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ChangeEnum.

--- a/okta/models/dns_record_type.py
+++ b/okta/models/dns_record_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class DnsRecordType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for DnsRecordType.

--- a/okta/models/domain_certificate_source_type.py
+++ b/okta/models/domain_certificate_source_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class DomainCertificateSourceType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for DomainCertificateSourceType.

--- a/okta/models/domain_certificate_type.py
+++ b/okta/models/domain_certificate_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class DomainCertificateType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for DomainCertificateType.

--- a/okta/models/domain_validation_status.py
+++ b/okta/models/domain_validation_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class DomainValidationStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for DomainValidationStatus.

--- a/okta/models/email_template_touch_point_variant.py
+++ b/okta/models/email_template_touch_point_variant.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class EmailTemplateTouchPointVariant(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for EmailTemplateTouchPointVariant.

--- a/okta/models/enabled_status.py
+++ b/okta/models/enabled_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class EnabledStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for EnabledStatus.

--- a/okta/models/end_user_dashboard_touch_point_variant.py
+++ b/okta/models/end_user_dashboard_touch_point_variant.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class EndUserDashboardTouchPointVariant(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for EndUserDashboardTouchPointVariant.

--- a/okta/models/error_page_touch_point_variant.py
+++ b/okta/models/error_page_touch_point_variant.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ErrorPageTouchPointVariant(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ErrorPageTouchPointVariant.

--- a/okta/models/event_hook_channel_config_auth_scheme_type.py
+++ b/okta/models/event_hook_channel_config_auth_scheme_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class EventHookChannelConfigAuthSchemeType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for EventHookChannelConfigAuthSchemeType.

--- a/okta/models/factor_provider.py
+++ b/okta/models/factor_provider.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FactorProvider(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FactorProvider.

--- a/okta/models/factor_result_type.py
+++ b/okta/models/factor_result_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FactorResultType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FactorResultType.

--- a/okta/models/factor_status.py
+++ b/okta/models/factor_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FactorStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FactorStatus.

--- a/okta/models/factor_type.py
+++ b/okta/models/factor_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FactorType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FactorType.

--- a/okta/models/feature_stage_state.py
+++ b/okta/models/feature_stage_state.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FeatureStageState(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FeatureStageState.

--- a/okta/models/feature_stage_value.py
+++ b/okta/models/feature_stage_value.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FeatureStageValue(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FeatureStageValue.

--- a/okta/models/feature_type.py
+++ b/okta/models/feature_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FeatureType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FeatureType.

--- a/okta/models/fips_enum.py
+++ b/okta/models/fips_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class FipsEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for FipsEnum.

--- a/okta/models/group_rule_status.py
+++ b/okta/models/group_rule_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class GroupRuleStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for GroupRuleStatus.

--- a/okta/models/group_type.py
+++ b/okta/models/group_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class GroupType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for GroupType.

--- a/okta/models/iframe_embed_scope_allowed_apps.py
+++ b/okta/models/iframe_embed_scope_allowed_apps.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class IframeEmbedScopeAllowedApps(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for IframeEmbedScopeAllowedApps.

--- a/okta/models/inline_hook_status.py
+++ b/okta/models/inline_hook_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class InlineHookStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for InlineHookStatus.

--- a/okta/models/inline_hook_type.py
+++ b/okta/models/inline_hook_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class InlineHookType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for InlineHookType.

--- a/okta/models/linked_object_details_type.py
+++ b/okta/models/linked_object_details_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class LinkedObjectDetailsType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for LinkedObjectDetailsType.

--- a/okta/models/log_authentication_provider.py
+++ b/okta/models/log_authentication_provider.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class LogAuthenticationProvider(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for LogAuthenticationProvider.

--- a/okta/models/log_credential_provider.py
+++ b/okta/models/log_credential_provider.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class LogCredentialProvider(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for LogCredentialProvider.

--- a/okta/models/log_credential_type.py
+++ b/okta/models/log_credential_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class LogCredentialType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for LogCredentialType.

--- a/okta/models/log_severity.py
+++ b/okta/models/log_severity.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class LogSeverity(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for LogSeverity.

--- a/okta/models/network_zone_address_type.py
+++ b/okta/models/network_zone_address_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class NetworkZoneAddressType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for NetworkZoneAddressType.

--- a/okta/models/network_zone_status.py
+++ b/okta/models/network_zone_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class NetworkZoneStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for NetworkZoneStatus.

--- a/okta/models/network_zone_type.py
+++ b/okta/models/network_zone_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class NetworkZoneType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for NetworkZoneType.

--- a/okta/models/network_zone_usage.py
+++ b/okta/models/network_zone_usage.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class NetworkZoneUsage(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for NetworkZoneUsage.

--- a/okta/models/notification_type.py
+++ b/okta/models/notification_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class NotificationType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for NotificationType.

--- a/okta/models/o_auth_2_scope_consent_grant_source.py
+++ b/okta/models/o_auth_2_scope_consent_grant_source.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OAuth2ScopeConsentGrantSource(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OAuth2ScopeConsentGrantSource.

--- a/okta/models/o_auth_2_scope_consent_grant_status.py
+++ b/okta/models/o_auth_2_scope_consent_grant_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OAuth2ScopeConsentGrantStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OAuth2ScopeConsentGrantStatus.

--- a/okta/models/o_auth_endpoint_authentication_method.py
+++ b/okta/models/o_auth_endpoint_authentication_method.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OAuthEndpointAuthenticationMethod(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OAuthEndpointAuthenticationMethod.

--- a/okta/models/o_auth_grant_type.py
+++ b/okta/models/o_auth_grant_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OAuthGrantType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OAuthGrantType.

--- a/okta/models/o_auth_response_type.py
+++ b/okta/models/o_auth_response_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OAuthResponseType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OAuthResponseType.

--- a/okta/models/open_id_connect_application_consent_method.py
+++ b/okta/models/open_id_connect_application_consent_method.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OpenIdConnectApplicationConsentMethod(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OpenIdConnectApplicationConsentMethod.

--- a/okta/models/open_id_connect_application_issuer_mode.py
+++ b/okta/models/open_id_connect_application_issuer_mode.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OpenIdConnectApplicationIssuerMode(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OpenIdConnectApplicationIssuerMode.

--- a/okta/models/open_id_connect_application_type.py
+++ b/okta/models/open_id_connect_application_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OpenIdConnectApplicationType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OpenIdConnectApplicationType.

--- a/okta/models/open_id_connect_refresh_token_rotation_type.py
+++ b/okta/models/open_id_connect_refresh_token_rotation_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OpenIdConnectRefreshTokenRotationType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OpenIdConnectRefreshTokenRotationType.

--- a/okta/models/org_contact_type.py
+++ b/okta/models/org_contact_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OrgContactType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OrgContactType.

--- a/okta/models/org_okta_support_setting.py
+++ b/okta/models/org_okta_support_setting.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class OrgOktaSupportSetting(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for OrgOktaSupportSetting.

--- a/okta/models/password_credential_hash_algorithm.py
+++ b/okta/models/password_credential_hash_algorithm.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class PasswordCredentialHashAlgorithm(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for PasswordCredentialHashAlgorithm.

--- a/okta/models/policy_rule_actions_enroll_self.py
+++ b/okta/models/policy_rule_actions_enroll_self.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class PolicyRuleActionsEnrollSelf(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for PolicyRuleActionsEnrollSelf.

--- a/okta/models/policy_subject_match_type.py
+++ b/okta/models/policy_subject_match_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class PolicySubjectMatchType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for PolicySubjectMatchType.

--- a/okta/models/policy_type.py
+++ b/okta/models/policy_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class PolicyType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for PolicyType.

--- a/okta/models/profile_mapping_property_push_status.py
+++ b/okta/models/profile_mapping_property_push_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ProfileMappingPropertyPushStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ProfileMappingPropertyPushStatus.

--- a/okta/models/protocol_relay_state_format.py
+++ b/okta/models/protocol_relay_state_format.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ProtocolRelayStateFormat(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ProtocolRelayStateFormat.

--- a/okta/models/provisioning_connection_auth_scheme.py
+++ b/okta/models/provisioning_connection_auth_scheme.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ProvisioningConnectionAuthScheme(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ProvisioningConnectionAuthScheme.

--- a/okta/models/provisioning_connection_status.py
+++ b/okta/models/provisioning_connection_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ProvisioningConnectionStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ProvisioningConnectionStatus.

--- a/okta/models/required_enum.py
+++ b/okta/models/required_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class RequiredEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for RequiredEnum.

--- a/okta/models/role_assignment_type.py
+++ b/okta/models/role_assignment_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class RoleAssignmentType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for RoleAssignmentType.

--- a/okta/models/role_status.py
+++ b/okta/models/role_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class RoleStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for RoleStatus.

--- a/okta/models/role_type.py
+++ b/okta/models/role_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class RoleType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for RoleType.

--- a/okta/models/scope_type.py
+++ b/okta/models/scope_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class ScopeType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for ScopeType.

--- a/okta/models/seed_enum.py
+++ b/okta/models/seed_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SeedEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SeedEnum.

--- a/okta/models/session_authentication_method.py
+++ b/okta/models/session_authentication_method.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SessionAuthenticationMethod(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SessionAuthenticationMethod.

--- a/okta/models/session_identity_provider_type.py
+++ b/okta/models/session_identity_provider_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SessionIdentityProviderType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SessionIdentityProviderType.

--- a/okta/models/session_status.py
+++ b/okta/models/session_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SessionStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SessionStatus.

--- a/okta/models/sign_in_page_touch_point_variant.py
+++ b/okta/models/sign_in_page_touch_point_variant.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SignInPageTouchPointVariant(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SignInPageTouchPointVariant.

--- a/okta/models/sms_template_type.py
+++ b/okta/models/sms_template_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SmsTemplateType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SmsTemplateType.

--- a/okta/models/subscription_status.py
+++ b/okta/models/subscription_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class SubscriptionStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for SubscriptionStatus.

--- a/okta/models/user_next_login.py
+++ b/okta/models/user_next_login.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserNextLogin(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserNextLogin.

--- a/okta/models/user_schema_attribute_master_type.py
+++ b/okta/models/user_schema_attribute_master_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserSchemaAttributeMasterType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserSchemaAttributeMasterType.

--- a/okta/models/user_schema_attribute_scope.py
+++ b/okta/models/user_schema_attribute_scope.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserSchemaAttributeScope(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserSchemaAttributeScope.

--- a/okta/models/user_schema_attribute_type.py
+++ b/okta/models/user_schema_attribute_type.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserSchemaAttributeType(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserSchemaAttributeType.

--- a/okta/models/user_schema_attribute_union.py
+++ b/okta/models/user_schema_attribute_union.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserSchemaAttributeUnion(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserSchemaAttributeUnion.

--- a/okta/models/user_status.py
+++ b/okta/models/user_status.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserStatus(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserStatus.

--- a/okta/models/user_verification_enum.py
+++ b/okta/models/user_verification_enum.py
@@ -18,12 +18,13 @@ limitations under the License.
 # AUTO-GENERATED! DO NOT EDIT FILE DIRECTLY
 # SEE CONTRIBUTOR DOCUMENTATION
 
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class UserVerificationEnum(
     str,
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for UserVerificationEnum.

--- a/openapi/templates/model.py.hbs
+++ b/openapi/templates/model.py.hbs
@@ -27,12 +27,13 @@ class {{pascalCase model.modelName}}(
             extend_enum(ApplicationSignOnMode, value_upper_case, value_upper_case)
             return getattr(cls, value_upper_case)
 {{else}}
-from aenum import MultiValueEnum
+from aenum import MultiValueEnum, ReprEnum
 
 
 class {{pascalCase model.modelName}}(
     {{model.type}},
-    MultiValueEnum
+    MultiValueEnum,
+    ReprEnum
 ):
     """
     An enumeration class for {{pascalCase model.modelName}}.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ pytest-asyncio
 pytest-mock
 pytest-recording
 pyfakefs
-aenum==3.1.11
+aenum
 pydash

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "yarl",
         "pycryptodomex",
         "python-jose",
-        "aenum==3.1.11",
+        "aenum",
         "pydash"
     ]
 )


### PR DESCRIPTION
Fixes #368

With the update of `aenum`, it seems that it breaks the formmating to enums.
Adding `ReprEnum` to these models so it format the string properly.

While regenerating the models, it did more changes than expected. I removed the non-related to ReprEnum changes.