### PR TITLE
Update saml_application_settings_sign_on.py

### DIFF
--- a/okta/models/saml_application_settings_sign_on.py
+++ b/okta/models/saml_application_settings_sign_on.py
@@ -62,6 +62,11 @@ class SamlApplicationSettingsSignOn(
                 if "audienceOverride" in config else None
             self.authn_context_class_ref = config["authnContextClassRef"]\
                 if "authnContextClassRef" in config else None
+            self.configured_attribute_statements = OktaCollection.form_list(
+                config["configuredAttributeStatements"] if "configuredAttributeStatements"\
+                    in config else [],
+                saml_attribute_statement.SamlAttributeStatement
+            )
             self.default_relay_state = config["defaultRelayState"]\
                 if "defaultRelayState" in config else None
             self.destination = config["destination"]\


### PR DESCRIPTION
When reading from OKTA API, SAML Applications that have preconfigured attribution statements are stored within 'configuredAttributeStatements'. 

This is currently not passed to the results var when using get_application 

This fix updates the model so that the value is passed