### PR TITLE
use latest ecdsa package to address vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pyyaml
 xmltodict
 yarl
 pycryptodomex
-python-jose
+python-jose==3.3.0
+    ecdsa==0.19.0
 aenum
 pydash
 flake8


### PR DESCRIPTION
A new version of ecdsa was released on April 8, 2024.  This change updates the requirements.txt file to reference the new version of the component.