### PR TITLE
Expire and renew the access token when using OAuth 2.0

### DIFF
--- a/okta/client.py
+++ b/okta/client.py
@@ -116,7 +116,7 @@ class Client(
         client_config_setter = ConfigSetter()
         client_config_setter._apply_config({'client': user_config})
         self._config = client_config_setter.get_config()
-        # Prune configuration to remove unnecesary fields
+        # Prune configuration to remove unnecessary fields
         self._config = client_config_setter._prune_config(self._config)
         # Validate configuration
         ConfigValidator(self._config)

--- a/okta/client.py
+++ b/okta/client.py
@@ -128,6 +128,7 @@ class Client(
         self._client_id = None
         self._scopes = None
         self._private_key = None
+        self._oauth_token_renewal_offset = None
 
         # Determine which cache to use
         cache = NoOpCache()
@@ -154,6 +155,7 @@ class Client(
             self._client_id = self._config["client"]["clientId"]
             self._scopes = self._config["client"]["scopes"]
             self._private_key = self._config["client"]["privateKey"]
+            self._oauth_token_renewal_offset = self._config["client"]["oauthTokenRenewalOffset"]
 
         setup_logging(log_level=self._config["client"]["logging"]["logLevel"])
         # Check if logging should be enabled

--- a/okta/config/config_setter.py
+++ b/okta/config/config_setter.py
@@ -37,7 +37,8 @@ class ConfigSetter():
             },
             "rateLimit": {
                 "maxRetries": ''
-            }
+            },
+            "oauthTokenRenewalOffset": ''
         },
         "testing": {
             "testingDisableHttpsCheck": ''
@@ -116,6 +117,7 @@ class ConfigSetter():
         self._config["client"]["rateLimit"] = {
             "maxRetries": 2
         }
+        self._config["client"]["oauthTokenRenewalOffset"] = 5
 
         self._config["testing"]["testingDisableHttpsCheck"] = False
 

--- a/okta/config/config_validator.py
+++ b/okta/config/config_validator.py
@@ -45,9 +45,8 @@ class ConfigValidator():
                 self._validate_token(
                     client.get('token', ""))
         elif client.get('authorizationMode') == "PrivateKey":
-            client_fields = ['clientId', 'scopes', 'privateKey']
-            client_fields_values = [self._config.get(
-                'client').get(field, "") for field in client_fields]
+            client_fields = ['clientId', 'scopes', 'privateKey', 'oauthTokenRenewalOffset']
+            client_fields_values = [client.get(field, "") for field in client_fields]
             errors += self._validate_client_fields(*client_fields_values)
         else:  # Not a valid authorization mode
             errors += [
@@ -61,7 +60,7 @@ class ConfigValidator():
                              f"See {REPO_URL} for usage")
 
     def _validate_client_fields(self, client_id, client_scopes,
-                                client_private_key):
+                                client_private_key, oauth_token_renewal_offset):
         client_fields_errors = []
 
         # check client id
@@ -76,6 +75,14 @@ class ConfigValidator():
         # check that at least 1 scope is provided and private key is provided
         if not (client_scopes and client_private_key):
             client_fields_errors.append(ERROR_MESSAGE_SCOPES_PK_MISSING)
+
+        # Validate oauthTokenRenewalOffset
+        if not oauth_token_renewal_offset:
+            client_fields_errors.append("oauthTokenRenewalOffset must be provided")
+        if not isinstance(oauth_token_renewal_offset, int):
+            client_fields_errors.append("oauthTokenRenewalOffset must be a valid integer")
+        if isinstance(oauth_token_renewal_offset, int) and oauth_token_renewal_offset < 0:
+            client_fields_errors.append("oauthTokenRenewalOffset must be a non-negative integer")
 
         return client_fields_errors
 

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -39,10 +39,11 @@ class OAuth:
             (if any)
         """
         
-        # Check if access token has expired or will expire in the next 5 minutes
+        # Check if access token has expired or will expire soon
         current_time = int(time.time())
         if self._access_token and hasattr(self, '_access_token_expiry_time'):
-            if current_time + 300 >= self._access_token_expiry_time:
+            renewal_offset = self._config["client"]["oauthTokenRenewalOffset"] * 60  # Convert minutes to seconds
+            if current_time + renewal_offset >= self._access_token_expiry_time:
                 self.clear_access_token()
         
         # Return token if already generated

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -1,3 +1,4 @@
+import time
 from urllib.parse import urlencode, quote
 from okta.jwt import JWT
 from okta.http_client import HTTPClient
@@ -37,6 +38,13 @@ class OAuth:
             str, Exception: Tuple of the access token, error that was raised
             (if any)
         """
+        
+        # Check if access token has expired or will expire in the next 5 minutes
+        current_time = int(time.time())
+        if self._access_token and hasattr(self, '_access_token_expiry_time'):
+            if current_time + 300 >= self._access_token_expiry_time:
+                self.clear_access_token()
+        
         # Return token if already generated
         if self._access_token:
             return (self._access_token, None)
@@ -83,6 +91,9 @@ class OAuth:
 
         # Otherwise set token and return it
         self._access_token = parsed_response["access_token"]
+        
+        # Set token expiry time
+        self._access_token_expiry_time = int(time.time()) + parsed_response["expires_in"]
         return (self._access_token, None)
 
     def clear_access_token(self):
@@ -92,3 +103,4 @@ class OAuth:
         self._access_token = None
         self._request_executor._cache.delete("OKTA_ACCESS_TOKEN")
         self._request_executor._default_headers.pop("Authorization", None)
+        self._access_token_expiry_time = None


### PR DESCRIPTION
This PR fixes https://github.com/okta/okta-sdk-python/issues/363 (Access token expiry not handled when using OAuth 2.0) by adding logic to expire and renew the access token when using OAuth 2.0 to authenticate with the Okta API. This issue and the fix was also discussed in PR #402 (Feature: Autorenew OAuth tokens]), but I believe this fix is simpler and superior, as it does not require importing any new libraries (other than time) and is more in line with the existing codebase.

I have reviewed the [CLA](https://developer.okta.com/cla/) and believe that this falls under the remit of an Obvious Fix and doesn't not require singing the CLA. I would be happy to do so however if the Okta team feels it is necessary.

I have also followed the steps [CONTRIBUTING](https://github.com/okta/okta-sdk-python/blob/master/CONTRIBUTING.md) guide when submitting this PR.

I don't have the ability to run the pytest suite on my work PC, but I've run this code manually by modifying the local okta-sdk-python and it works. I've also implemented a hotfix library that imports the Okta code, replaces the OAuth.py functions code with my code and runs it, and it works well.