### PR TITLE
Fix: missing LogCredentialType causes exception while reading log data

### DIFF
--- a/okta/models/log_credential_type.py
+++ b/okta/models/log_credential_type.py
@@ -37,3 +37,4 @@ class LogCredentialType(
     EMAIL = "EMAIL", "email"
     OAUTH_2 = "OAUTH2", "oauth2"
     JWT = "JWT", "jwt"
+    CERTIFICATE = "CERTIFICATE", "certificate"


### PR DESCRIPTION
While fetching and reading logs, we began hitting an unhandled exception of
```
ValueError: 'CERTIFICATE' is not a valid LogCredentialType
```

We determined this was from recently deploying FastPass and device integrations, which caused a new authentication type to appear in the logs.

I tracked this down to okta/models/log_credential_type.py, where based on the existing lines, the "CERTIFICATE" type was simply missing, so I've added that.