### PR TITLE
Allow latest aenum release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ pytest-asyncio
 pytest-mock
 pytest-recording
 pyfakefs
-aenum==3.1.11
+aenum
 pydash

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "pycryptodomex",
         "jwcrypto",
         "pyjwt",
-        "aenum==3.1.11",
+        "aenum",
         "pydash"
     ]
 )


### PR DESCRIPTION
Resolves:[https://github.com/okta/okta-sdk-python/issues/368]( https://github.com/okta/okta-sdk-python/issues/368)

aenum is pinned which causes various issues. As this is the only package to be pinned, eliminate the pinning.