### PR TITLE
Fixed #435: added data_type parameter for OktaAPIResponse

### DIFF
--- a/okta/api_response.py
+++ b/okta/api_response.py
@@ -180,7 +180,7 @@ class OktaAPIResponse():
             if next_request:
                 # create new response and update generator values
                 next_response = OktaAPIResponse(
-                    self._request_executor, req, res_details, resp_body)
+                    self._request_executor, req, res_details, resp_body, self._type)
                 self._next = next_response._next
                 # yield next page
                 yield (next_response.get_body(), None, next_response)


### PR DESCRIPTION
Fixed #435: added `data_type` parameter for `OktaAPIResponse`

The title and initial description blame `has_next`, but later comments clarify the issue is with inconsistent typing of results between pages. Added a unit test to show that the master branch currently has inconsistent types between pages. Resolved the issue by adding `data_type` parameter to `OktaAPIResponse` .

_I've emailed a signed CLA._