### PR TITLE
send_request should not update _default_headers

### DIFF
--- a/okta/http_client.py
+++ b/okta/http_client.py
@@ -65,11 +65,11 @@ class HTTPClient:
         try:
             logger.debug(f"Request: {request}")
             # Set headers
-            self._default_headers.update(request["headers"])
+            headers = {**self._default_headers, **request["headers"]}
             # Prepare request parameters
             params = {'method': request['method'],
                       'url': request['url'],
-                      'headers': self._default_headers}
+                      'headers': headers}
             if request['data']:
                 params['data'] = json.dumps(request['data'])
             elif request['form']:


### PR DESCRIPTION
`HTTPClient.send_request` updates its _default_headers with headers from its parameter.
I don't believe this is the thing that you want.