### PR TITLE
Add support for new Okta TLD domains (okta-gov.com, okta.mil, okta-miltest.com, trex-govcloud.com)

### DIFF
--- a/okta/config/config_validator.py
+++ b/okta/config/config_validator.py
@@ -164,6 +164,10 @@ class ConfigValidator:
             "-admin.okta.com",
             "-admin.oktapreview.com",
             "-admin.okta-emea.com",
+            "-admin.okta-gov.com",
+            "-admin.okta.mil",
+            "-admin.okta-miltest.com",
+            "-admin.trex-govcloud.com",
         ]
         if any(string in url for string in admin_strings) or "-admin" in url:
             url_errors.append(

--- a/openapi/management.yaml
+++ b/openapi/management.yaml
@@ -23,7 +23,7 @@ servers:
     variables:
       yourOktaDomain:
         default: subdomain.okta.com
-        description: The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, etc) or one of your configured custom domains.
+        description: The domain of your organization. This can be a provided subdomain of an official okta domain (okta.com, oktapreview.com, okta-gov.com, okta.mil, okta-miltest.com, trex-govcloud.com, etc) or one of your configured custom domains.
 tags:
   - name: AgentPools
     x-displayName: Agent Pools


### PR DESCRIPTION
## Summary
This PR adds support for new Okta TLD domains as part of the TG1 TLD Update initiative. The SDK now properly validates and accepts the following new domains:

- `okta-gov.com` - New production domain for OG1
- `okta.mil` - New production domain for OK15  
- `okta-miltest.com` - New test domain for testing transition
- `trex-govcloud.com` - New government cloud domain

## Changes Made
- **Domain Validation**: Updated config_validator.py to include new domains in admin keyword validation
- **OpenAPI Specs**: Updated management.yaml with new domains

## Issue Reference
Addresses TG1 TLD Update requirements for okta-sdk-python repository.