### PR TITLE
Refactor token handling, relax field validation, and remove duplicate client_assertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+.vscode/

--- a/okta/api_client.py
+++ b/okta/api_client.py
@@ -84,7 +84,7 @@ class ApiClient:
             configuration = Configuration.get_default()
         self.configuration = Configuration(
             host=configuration["client"]["orgUrl"],
-            access_token=configuration["client"]["token"],
+            access_token=configuration["client"].get("token", None),
             api_key=configuration["client"].get("privateKey", None),
             authorization_mode=configuration["client"].get("authorizationMode", "SSWS"),
         )

--- a/okta/models/user_profile.py
+++ b/okta/models/user_profile.py
@@ -61,7 +61,7 @@ class UserProfile(BaseModel):
     locale: Optional[StrictStr] = Field(
         default=None,
         description="The language specified as an [IETF BCP 47 language tag]("
-                    "https://datatracker.ietf.org/doc/html/rfc5646)",
+        "https://datatracker.ietf.org/doc/html/rfc5646)",
     )
     login: Optional[Annotated[str, Field(strict=True, max_length=100)]] = None
     manager: Optional[StrictStr] = None
@@ -83,7 +83,7 @@ class UserProfile(BaseModel):
     )
     profile_url: Optional[StrictStr] = Field(default=None, alias="profileUrl")
     second_email: Optional[
-        Annotated[str, Field(min_length=5, strict=True, max_length=100)]
+        Annotated[str, Field(min_length=0, strict=True, max_length=100)]
     ] = Field(default=None, alias="secondEmail")
     state: Optional[Annotated[str, Field(strict=True, max_length=128)]] = None
     street_address: Optional[Annotated[str, Field(strict=True, max_length=1024)]] = (

--- a/okta/oauth.py
+++ b/okta/oauth.py
@@ -82,7 +82,6 @@ class OAuth:
             "grant_type": "client_credentials",
             "scope": " ".join(self._config["client"]["scopes"]),
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion": jwt,
         }
 
         encoded_parameters = urlencode(parameters, quote_via=quote)

--- a/openapi/templates/api_client.mustache
+++ b/openapi/templates/api_client.mustache
@@ -87,7 +87,7 @@ class ApiClient:
             configuration = Configuration.get_default()
         self.configuration = Configuration(
             host=configuration["client"]["orgUrl"],
-            access_token=configuration["client"]["token"],
+            access_token=configuration["client"].get("token", None),
             api_key=configuration["client"].get("privateKey", None),
             authorization_mode=configuration["client"].get("authorizationMode", "SSWS"),
         )


### PR DESCRIPTION
This pull request introduces several minor but important improvements to error handling and data validation in the Okta API client and related models. The main changes include making token retrieval more robust, relaxing validation constraints for the `second_email` field, and removing an unused parameter in OAuth token generation.

**API Client Improvements:**

* Updated the initialization of `ApiClient` in both `okta/api_client.py` and the template `openapi/templates/api_client.mustache` to use `.get("token", None)` for accessing the token, preventing potential `KeyError` exceptions if the token is missing from the configuration. [[1]](diffhunk://#diff-3a75a2b79fd2af3c9c20f3fd3ec2f53bbeadceab45d752ff5044e37fb9bd5d82L87-R87) [[2]](diffhunk://#diff-8f485d665c39a4ce31d74cab415b750b39af3fe16458a65f052814de9c2fd2f9L90-R90)

**Model Validation Adjustments:**

* Relaxed the minimum length constraint for the `second_email` field in the `UserProfile` model, allowing it to be an empty string instead of requiring at least 5 characters.

**OAuth Logic Cleanup:**

* Removed the unused `client_assertion` parameter from the OAuth access token request, likely as part of cleaning up or correcting the OAuth client credentials flow.

Fixes #477 Fixes #473 