### PR TITLE
security: replace unsafe YAML loading with safe_load to prevent RCE

### DIFF
--- a/okta/okta_configuration.py
+++ b/okta/okta_configuration.py
@@ -23,14 +23,9 @@
 import os
 from pathlib import Path
 
-from yaml import load
+import yaml
 
 from okta.configuration import Configuration
-
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
 
 
 class OktaConfiguration():
@@ -43,8 +38,9 @@ class OktaConfiguration():
 
     def read_configuration(self, file_path) -> Configuration:
         if Path(file_path).is_file():
-            text = open(file_path).read()
-            okta_config = load(text, Loader=Loader)
+            with open(file_path, 'r') as f:
+                text = f.read()
+            okta_config = yaml.safe_load(text)
             config = Configuration()
             config.host = okta_config['oktaDomain']
             config.api_key['apiToken'] = okta_config['apiKey']


### PR DESCRIPTION
The current implementation in okta/okta_configuration.py utilizes yaml.load with potentially
  unsafe loaders, which is vulnerable to arbitrary code execution during deserialization of
  untrusted YAML input.

  Technical Root Cause:
  Unsafe loaders (like yaml.Loader or yaml.CLoader) allow the instantiation of any Python object,
  providing a direct vector for Remote Code Execution (RCE). Automated analysis has flagged this as
  a critical security risk when processing configuration files.

  Changes:
   - Migrated from yaml.load to yaml.safe_load to restrict deserialization to standard YAML types
     only.
   - Streamlined imports and removed unnecessary unsafe loader logic.
   - Implemented proper file context management using with statement for better resource handling.

  This hardening measure eliminates a critical attack vector and aligns the SDK with modern security
  standards for data serialization.