### PR TITLE
obvious fix: include _embedded field in device model

### DIFF
--- a/okta/models/device.py
+++ b/okta/models/device.py
@@ -70,6 +70,9 @@ class Device(BaseModel):
     )
     resource_type: Optional[StrictStr] = Field(default="UDDevice", alias="resourceType")
     status: Optional[DeviceStatus] = None
+    embedded: Optional[Dict[str, Any]] = Field(
+        default=None, alias="_embedded", description="Embedded resources like users when expand parameter is used"
+    )
     links: Optional[LinksSelfAndFullUsersLifecycle] = Field(
         default=None, alias="_links"
     )
@@ -83,6 +86,7 @@ class Device(BaseModel):
         "resourceId",
         "resourceType",
         "status",
+        "_embedded",
         "_links",
     ]
 

--- a/okta/models/device.py
+++ b/okta/models/device.py
@@ -197,6 +197,7 @@ class Device(BaseModel):
                     else "UDDevice"
                 ),
                 "status": obj.get("status"),
+                "_embedded": obj.get("_embedded"),
                 "_links": (
                     LinksSelfAndFullUsersLifecycle.from_dict(obj["_links"])
                     if obj.get("_links") is not None


### PR DESCRIPTION
`_embedded` is not actually included in the device model even though the documentation says so. This renders the `expand` parameter useless for the device api client. 