### PR TITLE
Fix: Primitive Fallback for oneOf Deserialization in Device Assurance Models

### DIFF
--- a/okta/models/by_duration_expiry.py
+++ b/okta/models/by_duration_expiry.py
@@ -51,11 +51,11 @@ class ByDurationExpiry(BaseModel):
             return value
 
         if not re.match(
-            r"^P(?:$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?:\d)(\d+H)?(\d+M)?(\d+S)?)?$",
+            r"^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$",
             value,
         ):
             raise ValueError(
-                r"must validate the regular expression /^P(?:$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?:\d)(\d+H)?(\d+M)?(\d+S)?)?$/"
+                r"must validate the regular expression /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/"
             )
         return value
 

--- a/okta/models/grace_period_expiry.py
+++ b/okta/models/grace_period_expiry.py
@@ -130,6 +130,44 @@ class GracePeriodExpiry(BaseModel):
         except (ValidationError, ValueError) as e:
             error_messages.append(str(e))
 
+        # If no match found and the data is a primitive value, retry by wrapping
+        # it into each oneOf schema's single-property structure. This handles API
+        # responses where a scalar is returned for a oneOf field whose schemas
+        # are single-property objects.
+        if match == 0:
+            try:
+                _parsed_value = json.loads(json_str)
+            except (json.JSONDecodeError, TypeError):
+                _parsed_value = None
+            if _parsed_value is not None and isinstance(
+                _parsed_value, (str, int, float, bool)
+            ):
+                _retry_error_messages = []
+                # retry ByDateTimeExpiry with wrapped primitive
+                try:
+                    _model_fields = list(ByDateTimeExpiry.model_fields.keys())
+                    if len(_model_fields) == 1:
+                        instance.actual_instance = ByDateTimeExpiry.model_validate(
+                            {_model_fields[0]: _parsed_value}
+                        )
+                        match += 1
+                except (ValidationError, ValueError) as e:
+                    _retry_error_messages.append(str(e))
+                # retry ByDurationExpiry with wrapped primitive
+                try:
+                    _model_fields = list(ByDurationExpiry.model_fields.keys())
+                    if len(_model_fields) == 1:
+                        instance.actual_instance = ByDurationExpiry.model_validate(
+                            {_model_fields[0]: _parsed_value}
+                        )
+                        match += 1
+                except (ValidationError, ValueError) as e:
+                    _retry_error_messages.append(str(e))
+                if match > 0:
+                    error_messages = _retry_error_messages
+                else:
+                    error_messages.extend(_retry_error_messages)
+
         if match > 1:
             # more than 1 match
             raise ValueError(

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -62100,7 +62100,7 @@ components:
         value:
           type: string
           description: A time duration in ISO 8601 duration format.
-          pattern: ^P(?:$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?:\d)(\d+H)?(\d+M)?(\d+S)?)?$
+          pattern: ^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$
     CAPTCHAInstance:
       title: CAPTCHAInstance
       description: ''
@@ -65855,6 +65855,7 @@ components:
       type: object
       properties:
         expiry:
+          x-okta-primitive-fallback: true
           oneOf:
             - $ref: '#/components/schemas/ByDateTimeExpiry'
             - $ref: '#/components/schemas/ByDurationExpiry'

--- a/openapi/templates/model_oneof.mustache
+++ b/openapi/templates/model_oneof.mustache
@@ -167,6 +167,40 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/isContainer}}
         {{/composedSchemas.oneOf}}
 
+        {{#vendorExtensions.x-okta-primitive-fallback}}
+        # If no match found and the data is a primitive value, retry by wrapping
+        # it into each oneOf schema's single-property structure. This handles API
+        # responses where a scalar is returned for a oneOf field whose schemas
+        # are single-property objects.
+        if match == 0:
+            try:
+                _parsed_value = json.loads(json_str)
+            except (json.JSONDecodeError, TypeError):
+                _parsed_value = None
+            if _parsed_value is not None and isinstance(_parsed_value, (str, int, float, bool)):
+                _retry_error_messages = []
+                {{#composedSchemas.oneOf}}
+                {{^isContainer}}
+                {{^isPrimitiveType}}
+                {{! Only retry non-primitive, non-container schemas. Primitive oneOf
+                    schemas would have already matched during the initial attempt above. }}
+                # retry {{{dataType}}} with wrapped primitive
+                try:
+                    _model_fields = list({{{dataType}}}.model_fields.keys())
+                    if len(_model_fields) == 1:
+                        instance.actual_instance = {{{dataType}}}.model_validate({_model_fields[0]: _parsed_value})
+                        match += 1
+                except (ValidationError, ValueError) as e:
+                    _retry_error_messages.append(str(e))
+                {{/isPrimitiveType}}
+                {{/isContainer}}
+                {{/composedSchemas.oneOf}}
+                if match > 0:
+                    error_messages = _retry_error_messages
+                else:
+                    error_messages.extend(_retry_error_messages)
+        {{/vendorExtensions.x-okta-primitive-fallback}}
+
         if match > 1:
             # more than 1 match
             raise ValueError("Multiple matches found when deserializing the JSON string into {{{classname}}} with oneOf schemas: {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Details: " + ", ".join(error_messages))


### PR DESCRIPTION
# Fix: Primitive Fallback for oneOf Deserialization in Device Assurance Models

## Summary

Adds a primitive-fallback retry mechanism to oneOf deserialization so that bare scalar API responses (e.g. `"2025-12-31T00:00:00Z"`) are automatically wrapped into the corresponding single-property schema object. Also fixes a malformed ISO 8601 duration regex that rejected all valid duration strings.

**Ticket**: OKTA-1154600

## Problem

The Okta API returns a raw primitive string for the `expiry` field inside Device Assurance policy responses, but the SDK's `GracePeriodExpiry` model expects a JSON object matching one of its `oneOf` schemas (`ByDateTimeExpiry` or `ByDurationExpiry`). This caused every call to the Device Assurance endpoints to fail:

```
ValidationError: No match found when deserializing the JSON string into
GracePeriodExpiry with oneOf schemas: ByDateTimeExpiry, ByDurationExpiry.
```

Affected endpoints:
- `list_device_assurance_policies()`
- `get_device_assurance_policy(policy_id)`

Additionally, the ISO 8601 duration regex contained incorrect constructs (`(?:$)` instead of the negative lookahead `(?!$)`, and `(?:\d)` instead of the positive lookahead `(?=\d)`), meaning it could never match valid duration strings like `P30D` or `PT1H`.

## Root Cause

1. **oneOf mismatch** — The API returns `"2025-12-31T00:00:00Z"` (a bare string), but the generated `from_json` method tries to parse it directly as `ByDateTimeExpiry` (which expects `{"value": "..."}`) and fails.
2. **Broken regex** — `(?:$)` is a non-capturing group containing end-of-string, not a negative lookahead. It causes the regex to silently fail on every non-empty input.

## Solution

### Files Changed

1. **`openapi/api.yaml`**
   - Added `x-okta-primitive-fallback: true` vendor extension on the `expiry` field of the `GracePeriod` schema.
   - Fixed the ISO 8601 duration regex on `ByDurationExpiry.value`:
     ```yaml
     # Before
     pattern: ^P(?:$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?:\d)(\d+H)?(\d+M)?(\d+S)?)?$
     # After
     pattern: ^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$
     ```

2. **`openapi/templates/model_oneof.mustache`**
   - Added a conditional block guarded by `x-okta-primitive-fallback` that:
     1. Parses the JSON string as a primitive.
     2. For each non-primitive oneOf schema with exactly one field, wraps the primitive in `{field_name: value}` and retries validation.
   - This is a generic, reusable template change — any future oneOf field that exhibits the same API behaviour only needs the vendor extension in the spec.

3. **`okta/models/grace_period_expiry.py`** *(regenerated)*
   - Contains the concrete fallback retry logic for `ByDateTimeExpiry` and `ByDurationExpiry`, generated from the updated mustache template.

4. **`okta/models/by_duration_expiry.py`** *(regenerated)*
   - Regex corrected from `(?:$)` → `(?!$)` and `(?:\d)` → `(?=\d)`.

## Testing

✅ Verified `list_device_assurance_policies()` returns fully deserialized policy objects
✅ Verified `get_device_assurance_policy(policy_id)` returns a correctly deserialized policy
✅ ISO 8601 duration strings (`P30D`, `PT1H`, `P1Y2M3DT4H5M6S`) now pass regex validation
✅ No breaking changes — the fallback only activates when the standard deserialization finds zero matches
✅ The mustache template change is backward-compatible; models without `x-okta-primitive-fallback` are unaffected

## How It Works

```
API Response: "2025-12-31T00:00:00Z"
                    │
                    ▼
    ┌──────────────────────────────┐
    │  Standard oneOf matching     │
    │  Try ByDateTimeExpiry → ✗    │
    │  Try ByDurationExpiry → ✗    │
    │  match == 0                  │
    └──────────────┬───────────────┘
                   │  x-okta-primitive-fallback
                   ▼
    ┌──────────────────────────────┐
    │  Primitive fallback retry    │
    │  Wrap as {"value": "2025-…"} │
    │  Try ByDateTimeExpiry → ✓    │
    │  match == 1                  │
    └──────────────────────────────┘
```
## Fixes
- https://github.com/okta/okta-sdk-python/issues/518