### PR TITLE
Resolve Dependabot Alerts: Upgrade Dependencies & GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/openapi/templates/pyproject.mustache
+++ b/openapi/templates/pyproject.mustache
@@ -29,9 +29,9 @@ pydantic = ">=2"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
+pytest = ">=8.4.2"
+tox = ">=4.30.3"
+flake8 = ">=7.3.0"
 types-python-dateutil = ">=2.8.19.14"
 mypy = "1.4.1"
 

--- a/openapi/templates/requirements.mustache
+++ b/openapi/templates/requirements.mustache
@@ -1,11 +1,11 @@
 aenum==3.1.16
-aiohttp==3.13.3
+aiohttp==3.13.4
 blinker==1.9.0
 jwcrypto==1.5.6
 pycryptodomex==3.23.0
 pydantic==2.11.3
 pydash==8.0.6
-PyJWT==2.11.0
+PyJWT==2.12.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.3
 requests==2.32.5

--- a/openapi/templates/requirements.mustache
+++ b/openapi/templates/requirements.mustache
@@ -8,7 +8,7 @@ pydash==8.0.6
 PyJWT==2.12.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.3
-requests==2.32.5
+requests==2.33.0
 xmltodict==1.0.2
 
 # Development & Testing Tools

--- a/openapi/templates/requirements.mustache
+++ b/openapi/templates/requirements.mustache
@@ -1,22 +1,22 @@
-aenum==3.1.11
-aiohttp==3.12.14
+aenum==3.1.16
+aiohttp==3.13.3
 blinker==1.9.0
 jwcrypto==1.5.6
 pycryptodomex==3.23.0
 pydantic==2.11.3
-pydash==8.0.5
-PyJWT==2.10.1
+pydash==8.0.6
+PyJWT==2.11.0
 python-dateutil==2.9.0.post0
-PyYAML==6.0.2
-requests==2.32.3
-xmltodict==0.14.2
+PyYAML==6.0.3
+requests==2.32.5
+xmltodict==1.0.2
 
 # Development & Testing Tools
-flake8==7.1.2
-pyfakefs==5.8.0
-pytest==8.3.5
-pytest-asyncio==0.26.0
-pytest-mock==3.14.0
-pytest-recording==0.13.2
-tox==4.24.2
-twine==6.1.0
+flake8==7.3.0
+pyfakefs==5.10.2
+pytest==8.4.2
+pytest-asyncio==1.2.0
+pytest-mock==3.15.1
+pytest-recording==0.13.4
+tox==4.30.3
+twine==6.2.0

--- a/openapi/templates/setup.mustache
+++ b/openapi/templates/setup.mustache
@@ -34,13 +34,13 @@ NAME = "okta"
 PYTHON_REQUIRES = ">=3.10"
 REQUIRES = [
     "aenum >= 3.1.16",
-    "aiohttp >= 3.13.3",
+    "aiohttp >= 3.13.4",
     "blinker >= 1.9.0",
     'jwcrypto >= 1.5.6',
     "pycryptodomex >= 3.23.0",
     "pydantic >= 2.11.3",
     "pydash >= 8.0.6",
-    "PyJWT >= 2.11.0",
+    "PyJWT >= 2.12.0",
     "python-dateutil >= 2.9.0.post0",
     "PyYAML >= 6.0.3",
     "requests >= 2.32.5",

--- a/openapi/templates/setup.mustache
+++ b/openapi/templates/setup.mustache
@@ -43,7 +43,7 @@ REQUIRES = [
     "PyJWT >= 2.12.0",
     "python-dateutil >= 2.9.0.post0",
     "PyYAML >= 6.0.3",
-    "requests >= 2.32.5",
+    "requests >= 2.33.0",
     "xmltodict >= 1.0.2",
 ]
 

--- a/openapi/templates/setup.mustache
+++ b/openapi/templates/setup.mustache
@@ -33,18 +33,18 @@ from setuptools import setup, find_packages  # noqa: H301
 NAME = "okta"
 PYTHON_REQUIRES = ">=3.10"
 REQUIRES = [
-    "aenum >= 3.1.11",
-    "aiohttp >= 3.12.14",
+    "aenum >= 3.1.16",
+    "aiohttp >= 3.13.3",
     "blinker >= 1.9.0",
     'jwcrypto >= 1.5.6',
     "pycryptodomex >= 3.23.0",
     "pydantic >= 2.11.3",
-    "pydash >= 8.0.5",
-    "PyJWT >= 2.10.1",
+    "pydash >= 8.0.6",
+    "PyJWT >= 2.11.0",
     "python-dateutil >= 2.9.0.post0",
-    "PyYAML >= 6.0.2",
-    "requests >= 2.32.3",
-    "xmltodict >= 0.14.2",
+    "PyYAML >= 6.0.3",
+    "requests >= 2.32.5",
+    "xmltodict >= 1.0.2",
 ]
 
 def get_version():

--- a/openapi/templates/test-requirements.mustache
+++ b/openapi/templates/test-requirements.mustache
@@ -1,4 +1,4 @@
-pytest~=7.1.3
+pytest~=8.4.2
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
 mypy>=1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ pydantic = ">=2"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=7.2.1"
-tox = ">=3.9.0"
-flake8 = ">=4.0.0"
+pytest = ">=8.4.2"
+tox = ">=4.30.3"
+flake8 = ">=7.3.0"
 types-python-dateutil = ">=2.8.19.14"
 mypy = "1.4.1"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 aenum==3.1.16
-aiohttp==3.13.3
+aiohttp==3.13.4
 blinker==1.9.0
 jwcrypto==1.5.6
 pycryptodomex==3.23.0
 pydantic==2.11.3
 pydash==8.0.6
-PyJWT==2.11.0
+PyJWT==2.12.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.3
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pydash==8.0.6
 PyJWT==2.12.0
 python-dateutil==2.9.0.post0
 PyYAML==6.0.3
-requests==2.32.5
+requests==2.33.0
 xmltodict==1.0.2
 
 # Development & Testing Tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-aenum==3.1.11
-aiohttp==3.12.14
+aenum==3.1.16
+aiohttp==3.13.3
 blinker==1.9.0
 jwcrypto==1.5.6
 pycryptodomex==3.23.0
 pydantic==2.11.3
-pydash==8.0.5
-PyJWT==2.10.1
+pydash==8.0.6
+PyJWT==2.11.0
 python-dateutil==2.9.0.post0
-PyYAML==6.0.2
-requests==2.32.3
-xmltodict==0.14.2
+PyYAML==6.0.3
+requests==2.32.5
+xmltodict==1.0.2
 
 # Development & Testing Tools
-flake8==7.1.2
-pyfakefs==5.8.0
-pytest==8.3.5
-pytest-asyncio==0.26.0
-pytest-mock==3.14.0
-pytest-recording==0.13.2
-tox==4.24.2
-twine==6.1.0
+flake8==7.3.0
+pyfakefs==5.10.2
+pytest==8.4.2
+pytest-asyncio==1.2.0
+pytest-mock==3.15.1
+pytest-recording==0.13.4
+tox==4.30.3
+twine==6.2.0

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,13 @@ NAME = "okta"
 PYTHON_REQUIRES = ">=3.10"
 REQUIRES = [
     "aenum >= 3.1.16",
-    "aiohttp >= 3.13.3",
+    "aiohttp >= 3.13.4",
     "blinker >= 1.9.0",
     'jwcrypto >= 1.5.6',
     "pycryptodomex >= 3.23.0",
     "pydantic >= 2.11.3",
     "pydash >= 8.0.6",
-    "PyJWT >= 2.11.0",
+    "PyJWT >= 2.12.0",
     "python-dateutil >= 2.9.0.post0",
     "PyYAML >= 6.0.3",
     "requests >= 2.32.5",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIRES = [
     "PyJWT >= 2.12.0",
     "python-dateutil >= 2.9.0.post0",
     "PyYAML >= 6.0.3",
-    "requests >= 2.32.5",
+    "requests >= 2.33.0",
     "xmltodict >= 1.0.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -33,18 +33,18 @@ from setuptools import setup, find_packages  # noqa: H301
 NAME = "okta"
 PYTHON_REQUIRES = ">=3.10"
 REQUIRES = [
-    "aenum >= 3.1.11",
-    "aiohttp >= 3.12.14",
+    "aenum >= 3.1.16",
+    "aiohttp >= 3.13.3",
     "blinker >= 1.9.0",
     'jwcrypto >= 1.5.6',
     "pycryptodomex >= 3.23.0",
     "pydantic >= 2.11.3",
-    "pydash >= 8.0.5",
-    "PyJWT >= 2.10.1",
+    "pydash >= 8.0.6",
+    "PyJWT >= 2.11.0",
     "python-dateutil >= 2.9.0.post0",
-    "PyYAML >= 6.0.2",
-    "requests >= 2.32.3",
-    "xmltodict >= 0.14.2",
+    "PyYAML >= 6.0.3",
+    "requests >= 2.32.5",
+    "xmltodict >= 1.0.2",
 ]
 
 def get_version():

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest~=7.1.3
+pytest~=8.4.2
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
 mypy>=1.4.1


### PR DESCRIPTION
# Resolve Dependabot Alerts: Upgrade Dependencies & GitHub Actions

## Summary

This PR addresses multiple Dependabot security alerts and version-bump PRs by upgrading all flagged runtime and development dependencies to their latest secure versions. It also bumps GitHub Actions (`actions/checkout`, `actions/setup-python`) to the current major release (v6) to eliminate Node.js 12/16 deprecation warnings.

## Motivation

Dependabot raised alerts and pull requests for several outdated packages that have known vulnerabilities or have since been superseded by newer secure releases. Rather than merging each Dependabot PR individually, this PR consolidates all the dependency bumps into a single change set for easier review and testing.

## Changes

### Runtime Dependencies (`requirements.txt`, `setup.py`, `pyproject.toml`)

| Package | Previous Version | New Version |
|---------|-----------------|-------------|
| aenum | 3.1.11 | 3.1.16 |
| aiohttp | 3.12.14 | 3.13.3 |
| pydash | 8.0.5 | 8.0.6 |
| PyJWT | 2.10.1 | 2.11.0 |
| PyYAML | 6.0.2 | 6.0.3 |
| requests | 2.32.3 | 2.32.5 |
| xmltodict | 0.14.2 | 1.0.2 |

### Development & Testing Dependencies (`requirements.txt`, `pyproject.toml`, `test-requirements.txt`)

| Package | Previous Version | New Version |
|---------|-----------------|-------------|
| flake8 | 7.1.2 / >=4.0.0 | 7.3.0 / >=7.3.0 |
| pyfakefs | 5.8.0 | 5.10.2 |
| pytest | 8.3.5 / ~=7.1.3 | 8.4.2 / ~=8.4.2 |
| pytest-asyncio | 0.26.0 | 1.2.0 |
| pytest-mock | 3.14.0 | 3.15.1 |
| pytest-recording | 0.13.2 | 0.13.4 |
| tox | 4.24.2 / >=3.9.0 | 4.30.3 / >=4.30.3 |
| twine | 6.1.0 | 6.2.0 |

### GitHub Actions (`.github/workflows/`)

| Action | Previous Version | New Version |
|--------|-----------------|-------------|
| actions/checkout | v2 / v3 | v6 |
| actions/setup-python | v2 / v4 | v6 |

### OpenAPI Generator Templates (`openapi/templates/`)

The mustache templates used for SDK code generation (`requirements.mustache`, `setup.mustache`, `pyproject.mustache`, `test-requirements.mustache`) have been updated to match the new dependency versions so that future regenerations remain consistent.

## Files Changed

- `.github/workflows/python-package.yml` — Bump checkout & setup-python actions
- `.github/workflows/python.yml` — Bump checkout & setup-python actions
- `requirements.txt` — Bump runtime + dev dependency versions
- `setup.py` — Bump runtime dependency version specifiers
- `pyproject.toml` — Bump dev dependency version specifiers
- `test-requirements.txt` — Bump pytest version specifier
- `openapi/templates/requirements.mustache` — Mirror requirements.txt updates
- `openapi/templates/setup.mustache` — Mirror setup.py updates
- `openapi/templates/pyproject.mustache` — Mirror pyproject.toml updates
- `openapi/templates/test-requirements.mustache` — Mirror test-requirements.txt updates

## Testing

- [x] CI passes with the updated dependency set (Python 3.10–3.13)
- [x] Integration tests (`pytest tests/integration`) pass
- [x] Linting (`flake8`) passes with the upgraded flake8 version

## Risk Assessment

**Low risk.** All changes are dependency version bumps to address known Dependabot alerts. No application logic or SDK API changes are included.

## Fixes
- #494 
- #493 
- #492
- #491 
- #486 
- #484 
- #480 
- #475 
- #461 
- #463 
- #465 
- #466 
- #467 
- #460 
- #453 
- #456 
- #458 
- #459 
