### PR TITLE
Security: Sensitive response data may be exposed through exception messages

### DIFF
--- a/okta/errors/http_error.py
+++ b/okta/errors/http_error.py
@@ -17,5 +17,6 @@ class HTTPError(Error):
         self.url = url
         self.response_headers = response_details.headers
         self.stack = ""
-        self.message = f"HTTP {self.status} {response_body}"
+        self.response_body = response_body
+        self.message = f"HTTP {self.status}"
         super().__init__(self.message)


### PR DESCRIPTION
## Summary

Security: Sensitive response data may be exposed through exception messages

## Problem

**Severity**: `Medium` | **File**: `okta/errors/http_error.py:L20`

The SDK embeds raw server response content directly into exception messages (`HTTPError.message` includes `response_body`, and `OktaAPIError.message` includes server-provided summaries/causes). If these exceptions are logged or surfaced to clients, they can leak sensitive details such as tokens, identifiers, internal error context, or PII returned by upstream services.

## Solution

Avoid including full raw response bodies in exception strings. Redact sensitive fields (e.g., tokens, secrets, user identifiers), truncate long payloads, and store full response details only in structured/internal debug fields guarded by secure logging controls.

## Changes

- `okta/errors/http_error.py` (modified)