### PR TITLE
fix: remove required constraints from SamlApplicationSettingsSignOn schema

### DIFF
--- a/docs/SamlApplicationSettingsSignOn.md
+++ b/docs/SamlApplicationSettingsSignOn.md
@@ -11,31 +11,31 @@ Name | Type | Description | Notes
 **assertion_encryption** | [**SamlAssertionEncryption**](SamlAssertionEncryption.md) |  | [optional] 
 **assertion_signed** | **bool** | Determines whether the SAML assertion is digitally signed | 
 **attribute_statements** | [**List[SamlAttributeStatement]**](SamlAttributeStatement.md) | A list of custom attribute statements for the app&#39;s SAML assertion. See [SAML 2.0 Technical Overview](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0-cd-02.html).  There are two types of attribute statements: | Type | Description | | ---- | ----------- | | EXPRESSION | Generic attribute statement that can be dynamic and supports [Okta Expression Language](https://developer.okta.com/docs/reference/okta-expression-language/) | | GROUP | Group attribute statement |  | [optional] 
-**audience** | **str** | The entity ID of the SP. Use the entity ID value exactly as provided by the SP. | 
+**audience** | **str** | The entity ID of the SP. Use the entity ID value exactly as provided by the SP. | [optional] 
 **audience_override** | **str** | Audience override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
-**authn_context_class_ref** | **str** | Identifies the SAML authentication context class for the assertion&#39;s authentication statement | 
+**authn_context_class_ref** | **str** | Identifies the SAML authentication context class for the assertion&#39;s authentication statement | [optional] 
 **configured_attribute_statements** | [**List[SamlAttributeStatement]**](SamlAttributeStatement.md) | The list of dynamic attribute statements for the SAML assertion inherited from app metadata (apps from the OIN) during app creation.  There are two types of attribute statements: &#x60;EXPRESSION&#x60; and &#x60;GROUP&#x60;.  | [optional] 
 **default_relay_state** | **str** | Identifies a specific application resource in an IdP-initiated SSO scenario | [optional] 
-**destination** | **str** | Identifies the location inside the SAML assertion where the SAML response should be sent | 
+**destination** | **str** | Identifies the location inside the SAML assertion where the SAML response should be sent | [optional] 
 **destination_override** | **str** | Destination override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
-**digest_algorithm** | **str** | Determines the digest algorithm used to digitally sign the SAML assertion and response | 
+**digest_algorithm** | **str** | Determines the digest algorithm used to digitally sign the SAML assertion and response | [optional] 
 **honor_force_authn** | **bool** | Set to &#x60;true&#x60; to prompt users for their credentials when a SAML request has the &#x60;ForceAuthn&#x60; attribute set to &#x60;true&#x60; | 
-**idp_issuer** | **str** | SAML Issuer ID | 
+**idp_issuer** | **str** | SAML Issuer ID | [optional] 
 **inline_hooks** | [**List[SignOnInlineHook]**](SignOnInlineHook.md) | Associates the app with SAML inline hooks. See [the SAML assertion inline hook reference](https://developer.okta.com/docs/reference/saml-hook/). | [optional] 
 **participate_slo** | [**SloParticipate**](SloParticipate.md) |  | [optional] 
-**recipient** | **str** | The location where the app may present the SAML assertion | 
+**recipient** | **str** | The location where the app may present the SAML assertion | [optional] 
 **recipient_override** | **str** | Recipient override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
 **request_compressed** | **bool** | Determines whether the SAML request is expected to be compressed | 
 **response_signed** | **bool** | Determines whether the SAML authentication response message is digitally signed by the IdP &gt; **Note:** Either (or both) &#x60;responseSigned&#x60; or &#x60;assertionSigned&#x60; must be &#x60;TRUE&#x60;. | 
 **saml_assertion_lifetime_seconds** | **int** | Determines the SAML app session lifetimes with Okta | [optional] 
-**signature_algorithm** | **str** | Determines the signing algorithm used to digitally sign the SAML assertion and response | 
+**signature_algorithm** | **str** | Determines the signing algorithm used to digitally sign the SAML assertion and response | [optional] 
 **slo** | [**SingleLogout**](SingleLogout.md) |  | [optional] 
 **sp_certificate** | [**SamlSpCertificate**](SamlSpCertificate.md) |  | [optional] 
 **sp_issuer** | **str** | The issuer ID for the Service Provider. This property appears when SLO is enabled. | [optional] 
-**sso_acs_url** | **str** | Single Sign-On Assertion Consumer Service (ACS) URL | 
+**sso_acs_url** | **str** | Single Sign-On Assertion Consumer Service (ACS) URL | [optional] 
 **sso_acs_url_override** | **str** | Assertion Consumer Service (ACS) URL override for CASB configuration. See [CASB config guide](https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm). | [optional] 
-**subject_name_id_format** | **str** | Identifies the SAML processing rules. Supported values: | 
-**subject_name_id_template** | **str** | Template for app user&#39;s username when a user is assigned to the app | 
+**subject_name_id_format** | **str** | Identifies the SAML processing rules. Supported values: | [optional] 
+**subject_name_id_template** | **str** | Template for app user&#39;s username when a user is assigned to the app | [optional] 
 
 ## Example
 

--- a/okta/models/saml_application_settings_sign_on.py
+++ b/okta/models/saml_application_settings_sign_on.py
@@ -80,8 +80,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
         "statement | ",
         alias="attributeStatements",
     )
-    audience: StrictStr = Field(
-        description="The entity ID of the SP. Use the entity ID value exactly as provided by the SP."
+    audience: Optional[StrictStr] = Field(
+        default=None,
+        description="The entity ID of the SP. Use the entity ID value exactly as provided by the SP.",
     )
     audience_override: Optional[StrictStr] = Field(
         default=None,
@@ -89,7 +90,8 @@ class SamlApplicationSettingsSignOn(BaseModel):
         "https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm).",
         alias="audienceOverride",
     )
-    authn_context_class_ref: StrictStr = Field(
+    authn_context_class_ref: Optional[StrictStr] = Field(
+        default=None,
         description="Identifies the SAML authentication context class for the assertion's authentication statement",
         alias="authnContextClassRef",
     )
@@ -104,8 +106,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
         description="Identifies a specific application resource in an IdP-initiated SSO scenario",
         alias="defaultRelayState",
     )
-    destination: StrictStr = Field(
-        description="Identifies the location inside the SAML assertion where the SAML response should be sent"
+    destination: Optional[StrictStr] = Field(
+        default=None,
+        description="Identifies the location inside the SAML assertion where the SAML response should be sent",
     )
     destination_override: Optional[StrictStr] = Field(
         default=None,
@@ -113,7 +116,8 @@ class SamlApplicationSettingsSignOn(BaseModel):
         "https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm).",
         alias="destinationOverride",
     )
-    digest_algorithm: StrictStr = Field(
+    digest_algorithm: Optional[StrictStr] = Field(
+        default=None,
         description="Determines the digest algorithm used to digitally sign the SAML assertion and response",
         alias="digestAlgorithm",
     )
@@ -122,7 +126,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
         "set to `true`",
         alias="honorForceAuthn",
     )
-    idp_issuer: StrictStr = Field(description="SAML Issuer ID", alias="idpIssuer")
+    idp_issuer: Optional[StrictStr] = Field(
+        default=None, description="SAML Issuer ID", alias="idpIssuer"
+    )
     inline_hooks: Optional[List[SignOnInlineHook]] = Field(
         default=None,
         description="Associates the app with SAML inline hooks. See [the SAML assertion inline hook reference]("
@@ -132,8 +138,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
     participate_slo: Optional[SloParticipate] = Field(
         default=None, alias="participateSlo"
     )
-    recipient: StrictStr = Field(
-        description="The location where the app may present the SAML assertion"
+    recipient: Optional[StrictStr] = Field(
+        default=None,
+        description="The location where the app may present the SAML assertion",
     )
     recipient_override: Optional[StrictStr] = Field(
         default=None,
@@ -155,7 +162,8 @@ class SamlApplicationSettingsSignOn(BaseModel):
         description="Determines the SAML app session lifetimes with Okta",
         alias="samlAssertionLifetimeSeconds",
     )
-    signature_algorithm: StrictStr = Field(
+    signature_algorithm: Optional[StrictStr] = Field(
+        default=None,
         description="Determines the signing algorithm used to digitally sign the SAML assertion and response",
         alias="signatureAlgorithm",
     )
@@ -168,7 +176,8 @@ class SamlApplicationSettingsSignOn(BaseModel):
         description="The issuer ID for the Service Provider. This property appears when SLO is enabled.",
         alias="spIssuer",
     )
-    sso_acs_url: StrictStr = Field(
+    sso_acs_url: Optional[StrictStr] = Field(
+        default=None,
         description="Single Sign-On Assertion Consumer Service (ACS) URL",
         alias="ssoAcsUrl",
     )
@@ -178,11 +187,13 @@ class SamlApplicationSettingsSignOn(BaseModel):
         "https://help.okta.com/en-us/Content/Topics/Apps/CASB-config-guide.htm).",
         alias="ssoAcsUrlOverride",
     )
-    subject_name_id_format: StrictStr = Field(
+    subject_name_id_format: Optional[StrictStr] = Field(
+        default=None,
         description="Identifies the SAML processing rules. Supported values:",
         alias="subjectNameIdFormat",
     )
-    subject_name_id_template: StrictStr = Field(
+    subject_name_id_template: Optional[StrictStr] = Field(
+        default=None,
         description="Template for app user's username when a user is assigned to the app",
         alias="subjectNameIdTemplate",
     )
@@ -222,6 +233,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
     @field_validator("authn_context_class_ref")
     def authn_context_class_ref_validate_enum(cls, value):
         """Validates the enum"""
+        if value is None:
+            return value
+
         if value not in set(
             [
                 "urn:federation:authentication:windows",
@@ -245,6 +259,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
     @field_validator("digest_algorithm")
     def digest_algorithm_validate_enum(cls, value):
         """Validates the enum"""
+        if value is None:
+            return value
+
         if value not in set(["SHA1", "SHA256"]):
             raise ValueError("must be one of enum values ('SHA1', 'SHA256')")
         return value
@@ -252,6 +269,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
     @field_validator("signature_algorithm")
     def signature_algorithm_validate_enum(cls, value):
         """Validates the enum"""
+        if value is None:
+            return value
+
         if value not in set(["RSA_SHA1", "RSA_SHA256"]):
             raise ValueError("must be one of enum values ('RSA_SHA1', 'RSA_SHA256')")
         return value
@@ -259,6 +279,9 @@ class SamlApplicationSettingsSignOn(BaseModel):
     @field_validator("subject_name_id_format")
     def subject_name_id_format_validate_enum(cls, value):
         """Validates the enum"""
+        if value is None:
+            return value
+
         if value not in set(
             [
                 "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -77143,19 +77143,9 @@ components:
       required:
         - allowMultipleAcsEndpoints
         - assertionSigned
-        - audience
-        - authnContextClassRef
-        - destination
-        - digestAlgorithm
         - honorForceAuthn
-        - idpIssuer
-        - recipient
         - requestCompressed
         - responseSigned
-        - signatureAlgorithm
-        - ssoAcsUrl
-        - subjectNameIdFormat
-        - subjectNameIdTemplate
     SamlAssertionEncryption:
       description: Determines if the app supports encrypted assertions
       type: object


### PR DESCRIPTION
## Remove required constraints from SamlApplicationSettingsSignOn schema

### Problem

The `SamlApplicationSettingsSignOn` schema in the Okta Admin Management API spec (`/api/v1/apps`) marks 16 fields as `required`. However, the `GET /api/v1/apps` endpoint returns SAML application objects where many of these fields are absent — specifically for partially configured SAML apps, which the API itself allows to be created.

SDK that enforces strict schema validation fails to deserialize the entire paginated response when even one partially configured SAML app is present on the page. This is currently blocking customers on the Python SDK.

**Customer reference:** [okta-sdk-python#536](https://github.com/okta/okta-sdk-python/issues/536)

### Changes

Removed the following 10 fields from the `required` array in the `SamlApplicationSettingsSignOn` schema:

| Field removed from `required` |
|-------------------------------|
| `audience` |
| `authnContextClassRef` |
| `destination` |
| `digestAlgorithm` |
| `idpIssuer` |
| `recipient` |
| `signatureAlgorithm` |
| `ssoAcsUrl` |
| `subjectNameIdFormat` |
| `subjectNameIdTemplate` |

The following 5 boolean fields are retained as `required` since the API consistently returns them:

- `allowMultipleAcsEndpoints`
- `assertionSigned`
- `honorForceAuthn`
- `requestCompressed`
- `responseSigned`

### How to reproduce the original issue

1. Create a SAML app via the Okta Admin console or API with minimal configuration (e.g., only provide `ssoAcsUrl`).
2. Call `GET /api/v1/apps?limit=200`.
3. Observe that the returned SAML app JSON is missing fields like `audience`, `destination`, `recipient`, `idpIssuer`, etc.
4. Any strict-validating SDK fails to deserialize the response.

### Testing

- Verified that the schema change is valid YAML and does not break the existing spec structure.

Closes #536
Closes OKTA-1172501