### PR TITLE
fix: upgrade dependencies to resolve Dependabot security alerts

### DIFF
--- a/openapi/templates/test-requirements.mustache
+++ b/openapi/templates/test-requirements.mustache
@@ -1,5 +1,5 @@
 pytest~=9.0.3
-pytest-cov>=2.8.1
-pytest-randomly>=3.12.0
+pytest-cov>=7.1.0
+pytest-randomly>=4.0.1
 mypy>=1.4.1
 types-python-dateutil>=2.8.19

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 pytest~=9.0.3
-pytest-cov>=2.8.1
-pytest-randomly>=3.12.0
+pytest-cov>=7.1.0
+pytest-randomly>=4.0.1
 mypy>=1.4.1
 types-python-dateutil>=2.8.19


### PR DESCRIPTION
Closes https://github.com/okta/okta-sdk-python/pull/538
Closes https://github.com/okta/okta-sdk-python/pull/537