### PR TITLE
Fix AWS log stream event source validation

### DIFF
--- a/okta/models/log_stream_settings_aws.py
+++ b/okta/models/log_stream_settings_aws.py
@@ -55,9 +55,9 @@ class LogStreamSettingsAws(BaseModel):
     @field_validator("event_source_name")
     def event_source_name_validate_regular_expression(cls, value):
         """Validates the regular expression"""
-        if not re.match(r"^[a-zA-Z0-9.\-_]$", value):
+        if not re.match(r"^[a-zA-Z0-9.\-_]+$", value):
             raise ValueError(
-                r"must validate the regular expression /^[a-zA-Z0-9.\-_]$/"
+                r"must validate the regular expression /^[a-zA-Z0-9.\-_]+$/"
             )
         return value
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -61407,7 +61407,7 @@ components:
       maxLength: 75
       example: your-event-source-name
       type: string
-      pattern: ^[a-zA-Z0-9.\-_]$
+      pattern: ^[a-zA-Z0-9.\-_]+$
     AwsRegion:
       description: The destination AWS region where your event source is located
       type: string

--- a/openapi/management.yaml
+++ b/openapi/management.yaml
@@ -23752,7 +23752,7 @@ components:
       maxLength: 75
       example: your-event-source-name
       type: string
-      pattern: ^[a-zA-Z0-9.\-_]$
+      pattern: ^[a-zA-Z0-9.\-_]+$
     AwsRegion:
       description: The destination AWS region where your event source is located
       type: string

--- a/tests/test_log_stream_settings_aws.py
+++ b/tests/test_log_stream_settings_aws.py
@@ -1,0 +1,70 @@
+import pytest
+from pydantic import ValidationError
+
+from okta.models.log_stream import LogStream
+from okta.models.log_stream_aws import LogStreamAws
+from okta.models.log_stream_settings_aws import LogStreamSettingsAws
+
+
+@pytest.mark.parametrize(
+    "event_source_name",
+    [
+        "p",
+        "MultiCharacter",
+        "event.source-name_123",
+        "a" * 75,
+    ],
+)
+def test_log_stream_settings_aws_accepts_valid_event_source_names(event_source_name):
+    settings = LogStreamSettingsAws(
+        accountId="123456789012",
+        eventSourceName=event_source_name,
+        region="us-east-1",
+    )
+
+    assert settings.event_source_name == event_source_name
+
+
+@pytest.mark.parametrize(
+    "event_source_name",
+    [
+        "",
+        "contains space",
+        "contains/slash",
+        "a" * 76,
+    ],
+)
+def test_log_stream_settings_aws_rejects_invalid_event_source_names(event_source_name):
+    with pytest.raises(ValidationError):
+        LogStreamSettingsAws(
+            accountId="123456789012",
+            eventSourceName=event_source_name,
+            region="us-east-1",
+        )
+
+
+def test_log_stream_aws_deserializes_multi_character_event_source_name():
+    log_stream = LogStream.from_dict(
+        {
+            "created": "2026-01-01T00:00:00.000Z",
+            "id": "logstream123",
+            "lastUpdated": "2026-01-01T00:00:00.000Z",
+            "name": "AWS EventBridge Log Stream",
+            "status": "ACTIVE",
+            "type": "aws_eventbridge",
+            "_links": {
+                "self": {
+                    "href": "/api/v1/logStreams/logstream123",
+                    "method": "GET",
+                }
+            },
+            "settings": {
+                "accountId": "123456789012",
+                "eventSourceName": "MultiCharacter",
+                "region": "us-east-1",
+            },
+        }
+    )
+
+    assert isinstance(log_stream, LogStreamAws)
+    assert log_stream.settings.event_source_name == "MultiCharacter"


### PR DESCRIPTION
## Summary
- Fixes AWS log stream `eventSourceName` validation to allow 1–75 valid characters instead of exactly one character.
- Updates both source OpenAPI schemas and the generated model validator.
- Adds regression coverage for direct `LogStreamSettingsAws` validation and `LogStream` AWS deserialization.

Fixes #549

## Tests
- `pytest tests/test_log_stream_settings_aws.py`
- `flake8 tests/test_log_stream_settings_aws.py`