### PR TITLE
fix: return the error instead of dereferencing a None response on transport failures

### DIFF
--- a/openapi/templates/api.mustache
+++ b/openapi/templates/api.mustache
@@ -68,6 +68,21 @@ class {{classname}}(ApiClient):
         response, response_body, error = await self._request_executor.execute(request)
         {{/returnType}}
 
+        # A transport-level failure (e.g. a dropped/reset connection or a timeout)
+        # makes execute() return a None response with the error set. Return that
+        # error before dereferencing response below, otherwise response.status
+        # raises AttributeError: 'NoneType' object has no attribute 'status'.
+        if response is None:
+            {{#returnType}}
+            if {{returnType}} is Success:
+                return (None, error)
+            else:
+                return (None, None, error)
+            {{/returnType}}
+            {{^returnType}}
+            return (None, error)
+            {{/returnType}}
+
         if response_body == '' or response.status == 204:
             response_data = RESTResponse(response)
             resp = ApiResponse(


### PR DESCRIPTION
## Summary

The generated API methods raise `AttributeError: 'NoneType' object has no attribute 'status'` on any transport-level failure, instead of returning the error in their `(data, response, error)` result tuple.

## Root cause

In `openapi/templates/api.mustache` (so every generated `okta/api/*_api.py` method), after `execute()` returns, the response is dereferenced before the error is checked:

```python
response, response_body, error = await self._request_executor.execute(request, ...)

if response_body == '' or response.status == 204:   # response can be None here
    ...
else:
    response_body = response_body.encode('utf-8')
    if error:                                        # error only checked here
        ...
```

`RequestExecutor.execute()` returns `(None, None, error)` on failure, and `HTTPClient.send_request` returns `(None, None, None, error)` for any `aiohttp.ClientError` / `asyncio.TimeoutError`. So a dropped/reset connection (e.g. a `ServerDisconnectedError` from reusing a pooled keep-alive the server has closed) or a socket timeout yields a `None` response with the error set — and `response.status` raises before the code ever inspects `error`.

Because it lives in the template, it affects every generated `list_*` / `get_*` / etc. method.

## Fix

Add an early guard that returns the error before the dereference, mirroring the existing `create_request` error handling:

```python
if response is None:
    if <ReturnType> is Success:
        return (None, error)
    else:
        return (None, None, error)
```

Only the null-response (transport-failure) path changes — it now returns the error in the tuple as documented, instead of raising. HTTP-error handling (a non-None response carrying an error) is untouched.

## Notes

- This is the **template change only**. The generated `okta/api/*_api.py` need to be regenerated with the pinned `openapi-generator-cli` 7.7.0 to propagate the fix; I wasn't able to run the JAR generation locally, so I've left that to the maintainers' pipeline. Happy to regenerate and/or add a regression test if you'd prefer it folded into this PR.
- Related to #487 (same template / generated methods; this is a separate defect in the post-`execute` response handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
